### PR TITLE
fix(strapi): secure toast display on `strapi:error` hook

### DIFF
--- a/plugins/strapi.client.ts
+++ b/plugins/strapi.client.ts
@@ -3,6 +3,6 @@ import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.hooks.hook('strapi:error' as any, (e: Strapi4Error) => {
-    nuxtApp.$toast.error({ title: e.error.name, description: e.error.message })
+    nuxtApp.$toast.error({ title: e.error?.name, description: e.error?.message })
   })
 })


### PR DESCRIPTION
Fixes #28 