### PR TITLE
fix: issue on `findIndex`s

### DIFF
--- a/pages/[team]/settings/index.vue
+++ b/pages/[team]/settings/index.vue
@@ -167,7 +167,7 @@ const updateUserTeam = (updatedTeam) => {
 }
 
 const removeTeamFromUser = () => {
-  const index = user.value?.memberships?.findIndex(m => m.team.id === props.team.id) || -1
+  const index = user.value?.memberships?.findIndex(m => m.team.id === props.team.id)
   if (index > -1) {
     user.value.memberships.splice(index, 1)
   }

--- a/pages/[team]/settings/members.vue
+++ b/pages/[team]/settings/members.vue
@@ -152,14 +152,14 @@ const onCopyInviteLink = () => {
 }
 
 const removeTeamFromUser = (team) => {
-  const index = user.value?.memberships?.findIndex(m => m.team.id === team.id) || -1
+  const index = user.value?.memberships?.findIndex(m => m.team.id === team.id)
   if (index > -1) {
     user.value.memberships.splice(index, 1)
   }
 }
 
 const removeMemberFromTeam = (member) => {
-  const index = props.team.members?.findIndex(m => m.id === member.id) || -1
+  const index = props.team.members?.findIndex(m => m.id === member.id)
   if (index > -1) {
     // eslint-disable-next-line vue/no-mutating-props
     props.team.members?.splice(index, 1)

--- a/pages/account/teams.vue
+++ b/pages/account/teams.vue
@@ -95,7 +95,7 @@ const client = useStrapiClient()
 
 const itemIconClass = ui.dropdown.item.icon
 
-const teams = ref(user.value.memberships.map(m => ({ role: m.role, ...m.team })))
+const teams = computed(() => user.value.memberships.map(m => ({ role: m.role, ...m.team })))
 const leaveModal = ref(false)
 const leavingTeam = ref(null)
 
@@ -104,7 +104,7 @@ const onCopyInviteLink = (team) => {
 }
 
 const removeTeamFromUser = (team) => {
-  const index = user.value?.memberships?.findIndex(m => m.team.id === team.id) || -1
+  const index = user.value?.memberships?.findIndex(m => m.team.id === team.id)
   if (index > -1) {
     user.value.memberships.splice(index, 1)
   }


### PR DESCRIPTION
I made an error while writing the first `removeMemberFromTeam` and it went viral. I didn't know JS handle well the fact that `index > -1` works well with a `index: null`, and my writing had the side effect of not properly handling `index: 0`.