### PR TITLE
fix(project): fetch content on revert

### DIFF
--- a/composables/useProjectFiles.ts
+++ b/composables/useProjectFiles.ts
@@ -127,12 +127,11 @@ export const useProjectFiles = (project: Project, root: string) => {
         file.value = null
         init()
       }
+    } else {
+      // No new selection, fetch new content
+      // FIXME: hacky update to trigger any watchers on `file`
+      file.value = { ...file.value }
     }
-    // TODO
-    // else {
-    //   // No new selection, fetch new content
-    //   await fetchContent()
-    // }
   }
 
   async function _delete (path: string) {


### PR DESCRIPTION
Hacky fix, but it works well. I don't see any other way to trigger the watch.
It would also work for any `watch(file, () => {})` in `media.vue`.