### PR TITLE
feat(project): prevent upload of file with same path

### DIFF
--- a/pages/@[team]/[project]/media.vue
+++ b/pages/@[team]/[project]/media.vue
@@ -32,7 +32,7 @@
 import type { PropType, Ref } from 'vue'
 import { isEmpty } from 'lodash-es'
 import type { Team, Project } from '~/types'
-import { getAvailablePath } from '~~/utils/tree'
+import { getAvailablePath } from '~/utils/tree'
 
 const props = defineProps({
   team: {

--- a/utils/tree.ts
+++ b/utils/tree.ts
@@ -68,9 +68,9 @@ export const renamePath = function (path: string, newPath: string, newPrefix: st
   return `${newDir}/${newName}`
 }
 
-export const getAvailablePath = (path: string, tree: File[]): string => {
+export const getAvailablePath = (path: string, files: File[]): string => {
   // Check if path is available
-  let pathAvailable = !tree.find((file: File) => file.path === path)
+  let pathAvailable = !files.find((file: File) => file.path === path)
   if (pathAvailable) {
     return path
   }
@@ -85,7 +85,7 @@ export const getAvailablePath = (path: string, tree: File[]): string => {
   while (!newPath) {
     const suffixedPath = `${dir}/${filename}-${suffix}.${ext}`
 
-    pathAvailable = !tree.find((file: File) => file.path === suffixedPath)
+    pathAvailable = !files.find((file: File) => file.path === suffixedPath)
     if (pathAvailable) {
       newPath = suffixedPath
     }


### PR DESCRIPTION
Resolves #232 

https://www.loom.com/share/cacca7dc98bc4e7aa99f3265cac92b7f

---

One special case exists and is maybe not ideal:
- I have a file `wtf.png`
- I delete `wtf.png` (from the draft, no commit)
- I upload a new `wtf.png` => It is still renamed `wtf-1.png` because the other one exists in the current files

Even if I ignore deleted files and put `wtf.png` to replace the deleted one, it considers the deleted one as not deleted (like reverted) instead of marking it as updated.
I don't know if we want to work on that case.