### PR TITLE
feat(project): handle drag&drop media files upload

### DIFF
--- a/pages/@[team]/[project]/media.vue
+++ b/pages/@[team]/[project]/media.vue
@@ -26,20 +26,23 @@
     </template>
 
     <div class="flex items-stretch flex-1 min-h-0 overflow-hidden">
-      <div class="flex-1 flex flex-col relative">
-        <div
-          class="absolute inset-0 border border-transparent"
-          :class="{ 'bg-blue-200 border-blue-500': dragover }"
-          @dragover.prevent
-          @dragenter.prevent="dragover = true"
-          @dragleave.prevent="dragover = false"
-          @drop.prevent="drop"
-        />
-
+      <div
+        class="flex-1 flex flex-col relative"
+        @dragover.prevent
+        @dragenter.prevent="onDragEnter"
+        @dragleave.prevent="onDragLeave"
+        @drop.prevent="onDrop"
+      >
         <div v-if="computedFiles.length" class="flex-1 flex flex-col p-4 sm:p-6 overflow-y-auto">
           <ProjectMediaFilesGallery />
         </div>
         <ProjectMediaFilesEmpty v-else @create="$refs.fileToUpload.click()" />
+
+        <div
+          class="absolute inset-0 border border-dashed border-transparent"
+          :class="{ 'bg-blue-500 bg-opacity-20 border-blue-500': dragover }"
+          style="pointer-events: none;"
+        />
       </div>
 
       <ProjectMediaFileAside />
@@ -77,7 +80,19 @@ const dragover = ref(false)
 
 // Methods
 
-function drop (e) {
+function onDragEnter (e) {
+  dragover.value = true
+}
+
+function onDragLeave (e) {
+  if (e.currentTarget.contains(e.relatedTarget)) {
+    return
+  }
+
+  dragover.value = false
+}
+
+function onDrop (e) {
   dragover.value = false
   fileToUpload.value.files = e.dataTransfer.files
   onFileUpload()


### PR DESCRIPTION
Resolves #204 
Also handle multiple files

Drop event is handled in a specific absolute div to avoid an HTML behavior: https://stackoverflow.com/questions/7110353/html5-dragleave-fired-when-hovering-a-child-element
I couldn't simply add it on the "main" div, or it would conflict when hovering medias of the gallery which are child.

https://www.loom.com/share/8d3476542ab744c59e8209d0e49c2680
