### PR TITLE
fix(footer): lang select broken

### DIFF
--- a/components/organisms/Footer.vue
+++ b/components/organisms/Footer.vue
@@ -100,5 +100,5 @@ const { data: footerData } = await useAsyncData('footer-content', findOne)
 const { legalLinks, links, socialLinks } = footerData.value
 
 const langs = ref([{ text: 'English', value: 'en' }])
-const lang = ref(langs.value[0])
+const lang = ref(langs.value[0].value)
 </script>


### PR DESCRIPTION
Fixes #220 

I remember fixing it but can't find any commit about it 🤷 
It was just that the initial value was incorrect. `v-model` value for `Select` must be `'en'`, not `{ "text": "English", "value": "en" }`