### PR TITLE
fix(project): drag&drop non-prefixed files behavior

### DIFF
--- a/composables/useProjectFilesTree.ts
+++ b/composables/useProjectFilesTree.ts
@@ -1,5 +1,5 @@
 import type { GitHubFile, Project, Root } from '~/types'
-import { mapTree, findTree, renamePath, getPathDir } from '~/utils/tree'
+import { mapTree, findTree, renamePath, getPathDir, getPathPrefix } from '~/utils/tree'
 
 const openedDirs = reactive({})
 
@@ -42,23 +42,35 @@ export const useProjectFilesTree = (project: Project, root: Root) => {
     if (sameTree) {
       if (srcIndex > dstIndex) {
         // I move a file up
-        for (let i = position === 'below' ? (dstIndex + 1) : dstIndex; i < srcIndex; i++) {
-          filesToRename.push({ oldPath: srcTree[i].path, newPath: renamePath(srcTree[i].path, srcTree[i].path, i + 2) })
+        const startIndex = position === 'below' ? (dstIndex + 1) : dstIndex
+        for (let i = startIndex; i < srcIndex; i++) {
+          if (getPathPrefix(srcTree[i].path) !== null) {
+            filesToRename.push({ oldPath: srcTree[i].path, newPath: renamePath(srcTree[i].path, srcTree[i].path, i + 2) })
+          }
         }
       } else {
         // I move a file down
-        for (let i = position === 'above' ? (dstIndex - 1) : dstIndex; i > srcIndex; i--) {
-          filesToRename.push({ oldPath: srcTree[i].path, newPath: renamePath(srcTree[i].path, srcTree[i].path, i) })
+        const startIndex = position === 'above' ? (dstIndex - 1) : dstIndex
+        for (let i = startIndex; i > srcIndex; i--) {
+          if (getPathPrefix(srcTree[i].path) !== null) {
+            filesToRename.push({ oldPath: srcTree[i].path, newPath: renamePath(srcTree[i].path, srcTree[i].path, i) })
+          }
         }
       }
     } else {
       // Rename `srcTree` files after `srcIndex`
-      for (let i = srcIndex + 1; i < srcTree.length; i++) {
-        filesToRename.push({ oldPath: srcTree[i].path, newPath: renamePath(srcTree[i].path, srcTree[i].path, i) })
+      let startIndex = srcIndex + 1
+      for (let i = startIndex; i < srcTree.length; i++) {
+        if (getPathPrefix(srcTree[i].path) !== null) {
+          filesToRename.push({ oldPath: srcTree[i].path, newPath: renamePath(srcTree[i].path, srcTree[i].path, i) })
+        }
       }
       // Rename `dstTree` files after `dstIndex`
-      for (let i = position === 'below' ? (dstIndex + 1) : dstIndex; i < dstTree.length; i++) {
-        filesToRename.push({ oldPath: dstTree[i].path, newPath: renamePath(dstTree[i].path, dstTree[i].path, i + 2) })
+      startIndex = position === 'below' ? (dstIndex + 1) : dstIndex
+      for (let i = startIndex; i < dstTree.length; i++) {
+        if (getPathPrefix(dstTree[i].path) !== null) {
+          filesToRename.push({ oldPath: dstTree[i].path, newPath: renamePath(dstTree[i].path, dstTree[i].path, i + 2) })
+        }
       }
     }
 

--- a/utils/tree.ts
+++ b/utils/tree.ts
@@ -39,15 +39,7 @@ export const findTree = function (path: string, tree: File[]): any {
 }
 
 export const replacePrefix = function (path: string, newPrefix: string) {
-  const split = path.split('/')
-  let [prefix, name, ext] = split.pop()?.split('.') || []
-  // Case when file has no prefix
-  if (!Number(prefix)) {
-    ext = name
-    name = prefix
-    prefix = null
-  }
-
+  const { name, ext } = destructurePathName(getPathName(path))
   return `${newPrefix}.${name}.${ext}`
 }
 
@@ -57,6 +49,42 @@ export const getPathDir = function (path: string) {
 
 export const getPathName = function (path: string) {
   return path.replace(/^.*[\\/]/, '')
+}
+
+export const getPathPrefix = function (path: string) {
+  const destr = destructurePathName(getPathName(path))
+  return destr.prefix
+}
+
+export const isPrefix = function (prefix: string | null) {
+  // allows ['0'], disallows [null, 'foo']
+  return typeof prefix === 'string' && !isNaN(Number(prefix))
+}
+
+export const destructurePathName = function (path: string) {
+  const split = getPathName(path).split('.')
+  let prefix: string | null = null
+  let name: string | null = null
+  let ext: string | null = null
+
+  if (split.length <= 1) {
+    name = path
+    return { prefix, name, ext }
+  }
+
+  if (split.length === 2) {
+    name = split[0]
+    ext = split[1]
+    return { prefix, name, ext }
+  }
+
+  prefix = split.length >= 3 ? split[0] : null
+  if (!isPrefix(prefix)) {
+    prefix = null
+  }
+  ext = split[split.length - 1]
+  name = split.slice(prefix ? 1 : 0, split.length - 1).join('.')
+  return { prefix, name, ext }
 }
 
 export const renamePath = function (path: string, newPath: string, newPrefix: string) {


### PR DESCRIPTION
Fixes #192 

---

The decided behavior is that only prefixed files are included in the renaming.

This also made me improve some tree utils to better detect prefix and handle manipulations. (the current method of prefix extraction had weaknesses)
I created `destructurePathName` to determine once and for all the 3 components of a filename, avoiding to split multiple times in case we need to use multiple components of it.
Here are the results of the new/modified methods:

```
destructurePathName('toto') => { prefix: null, name: 'toto', ext: null }
destructurePathName('toto.md') => { prefix: null, name: 'toto', ext: 'md' }
destructurePathName('0.toto.md') => { prefix: '0', name: 'toto', ext: 'md' }
destructurePathName('0.toto.tata.md') => { prefix: '0', name: 'toto.tata', ext: 'md' }
destructurePathName('.ignore') => { prefix: null, name: '', ext: 'ignore' }
destructurePathName('foo.') => { prefix: null, name: 'foo', ext: '' }
destructurePathName('.') => { prefix: null, name: '', ext: '' }
```
```
replacePrefix('toto', '8') => '8.toto.null'
replacePrefix('toto.md', '8') => '8.toto.md'
replacePrefix('0.toto.md', '8') => '8.toto.md'
replacePrefix('0.toto.tata.md', '8') => '8.toto.tata.md'
replacePrefix('.ignore', '8') => '8..ignore'
replacePrefix('foo.', '8') => '8.foo.'
replacePrefix('.', '8') => '8..'
```

Some results are unexpected. I can fix it but I am just waiting for approval of the enhancement. Otherwise it does not matter.