### PR TITLE
feat(project): add tabs to content and media asides

### DIFF
--- a/components/project/content/ProjectContentFileAside.vue
+++ b/components/project/content/ProjectContentFileAside.vue
@@ -21,12 +21,16 @@
       </div>
 
       <div>
-        <nav class="flex h-16 space-x-4 border-b u-border-gray-200 px-6">
+        <nav class="flex h-12 space-x-4 border-b u-border-gray-200 px-6">
           <button
             v-for="(category, index) in ['Meta', 'History']"
             :key="index"
-            :class="{ 'font-medium u-text-black u-border-gray-600': selectedIndex === index }"
-            class="u-text-gray-800 border-b border-transparent px-2 -mb-[1px]"
+            :class="{
+              'font-medium u-text-gray-900 u-border-gray-700': selectedIndex === index,
+              'u-text-gray-500 hover:u-text-gray-900 border-transparent': selectedIndex !== index
+            }"
+            class="border-b-2 px-2 -mb-px focus:outline-none"
+            tabindex="-1"
             @click="selectedIndex = index"
           >
             {{ category }}

--- a/components/project/file/ProjectFileHistory.vue
+++ b/components/project/file/ProjectFileHistory.vue
@@ -6,7 +6,7 @@
     <li v-else-if="!history?.length" class="py-3 text-sm text-center">
       No history yet
     </li>
-    <li v-for="commit in history" v-else :key="commit.oid" class="flex justify-between py-3 gap-3">
+    <li v-for="commit in history" v-else :key="commit.oid" class="flex justify-between py-3 first:pt-0 last:pb-0 gap-3">
       <div class="flex flex-1 min-w-0">
         <div class="flex flex-col -space-y-1.5">
           <UAvatar v-for="author of [...commit.authors].slice(0, 3)" :key="author.login" :src="author.avatarUrl" :alt="author.login" size="xs" />
@@ -18,7 +18,7 @@
             </p>
             <time v-if="commit.date" class="block u-text-gray-400 text-sm flex-shrink-0">{{ useTimeAgo(new Date(commit.date)).value }}</time>
           </div>
-          <NuxtLink :to="`https://github.com/${project.repository.owner}/${project.repository.name}/commit/${commit.oid}`" target="_blank" class="flex-shrink-0 u-text-gray-500 hover:underline text-sm block">
+          <NuxtLink :to="`https://github.com/${project.repository.owner}/${project.repository.name}/commit/${commit.oid}`" target="_blank" class="flex-shrink-0 u-text-gray-500 hover:underline text-sm block" tabindex="-1">
             <span class="line-clamp-2">{{ commit.message }}</span>
           </NuxtLink>
         </div>

--- a/components/project/media/ProjectMediaFileAside.vue
+++ b/components/project/media/ProjectMediaFileAside.vue
@@ -19,18 +19,22 @@
           </p>
         </div>
 
-        <a :download="computedFile.name" :href="fileDownloadLink">
-          <UButton icon="heroicons-outline:cloud-download" variant="gray" rounded />
+        <a v-if="fileDownloadLink" :download="computedFile.name" :href="fileDownloadLink" tabindex="-1" class="focus:outline-none focus:ring-offset-white dark:focus:ring-offset-black p-2 u-bg-gray-100 hover:u-bg-gray-200 focus:ring-2 focus:ring-offset-2 focus:u-ring-gray-900 rounded-full">
+          <UIcon name="heroicons-outline:cloud-download" class="w-5 h-5" />
         </a>
       </div>
 
       <div>
-        <nav class="flex h-16 space-x-4 border-b u-border-gray-200 px-6">
+        <nav class="flex h-12 space-x-4 border-b u-border-gray-200 px-6">
           <button
             v-for="(category, index) in ['Meta', 'History']"
             :key="index"
-            :class="{ 'font-medium u-text-black u-border-gray-600': selectedIndex === index }"
-            class="u-text-gray-800 border-b border-transparent px-2 -mb-[1px]"
+            :class="{
+              'font-medium u-text-gray-900 u-border-gray-700': selectedIndex === index,
+              'u-text-gray-500 hover:u-text-gray-900 border-transparent': selectedIndex !== index
+            }"
+            class="border-b-2 px-2 -mb-px focus:outline-none"
+            tabindex="-1"
             @click="selectedIndex = index"
           >
             {{ category }}
@@ -39,8 +43,8 @@
 
         <div class="p-6">
           <div v-if="selectedIndex === 0" class="space-y-6">
-            <dl class="border-b u-border-gray-200 divide-y u-divide-gray-200">
-              <div class="flex justify-between py-3 text-sm font-medium">
+            <dl class="divide-y u-divide-gray-200">
+              <div class="flex justify-between pb-3 text-sm font-medium">
                 <dt class="u-text-gray-500">
                   Size
                 </dt>
@@ -48,7 +52,7 @@
                   {{ toFormattedBytes(computedFile.size) }}
                 </dd>
               </div>
-              <div v-if="medias[computedFile.path]" class="flex justify-between py-3 text-sm font-medium">
+              <div v-if="medias[computedFile.path]" class="flex justify-between pt-3 text-sm font-medium">
                 <dt class="u-text-gray-500">
                   Dimensions
                 </dt>
@@ -78,7 +82,7 @@
 import type { Project, Root } from '~/types'
 import { toFormattedBytes } from '~/utils'
 
-defineProps({
+const props = defineProps({
   medias: {
     type: Object,
     default: () => ({})
@@ -99,5 +103,13 @@ const absolutePath = computed(() => {
     .join('/')
 })
 
-const fileDownloadLink = computed(() => `data:image/png;base64,${computedFile.value?.content}`)
+const fileDownloadLink = computed(() => {
+  if (!computedFile.value) {
+    return
+  }
+
+  if (props.medias[computedFile.value.path]) {
+    return `data:image/png;base64,${props.medias[computedFile.value.path].content}`
+  }
+})
 </script>


### PR DESCRIPTION
Resolves #450 

Notes:
- `useState` is used to remember active tab of each aside
- File history is fetched every time user selects History tab
- Not using HeadlessUI Tabs because it does not work on server render
