### PR TITLE
fix(community): improve nuxters endpoint to leverage caching

### DIFF
--- a/composables/useCommunityNuxters.ts
+++ b/composables/useCommunityNuxters.ts
@@ -27,11 +27,7 @@ export const useCommunityNuxters = () => {
     const time = date.toISOString().split('T', 1)[0]
 
     try {
-      const data = await $fetch('/api/community/nuxters', {
-        params: {
-          time
-        }
-      })
+      const data = await $fetch(`/api/community/nuxters/${time}`)
 
       _nuxters.value = data
     } catch (e) {

--- a/server/api/community/nuxters/[date].ts
+++ b/server/api/community/nuxters/[date].ts
@@ -30,22 +30,22 @@ const fetchOrbitAndPaginate = async (url: string, { headers = {}, params = {}, m
 }
 
 export default defineCachedEventHandler(async (event) => {
-  const { time, limit = 100 } = useQuery(event)
+  const date = event.context.params.date
 
   // Fetch Orbit members
   const { data: members } = await fetchOrbitAndPaginate('/nuxtjs/members', {
     params: {
       identity: 'github',
-      items: 100,
+      items: 120,
       sort: 'activities_count',
-      start_date: time
+      start_date: date
     },
     maxPage: 1
   })
 
   const nuxters = members
     .filter(member => !member.attributes.tags.includes('bot'))
-    .slice(0, Number(limit))
+    .slice(0, 100)
     .map((member) => {
       const m = member.attributes
       return {


### PR DESCRIPTION
Otherwise Vercel was caching the endpoint whatever que query params is (`?time=` was not affecting Vercel caching)