### PR TITLE
Add Mastering Nuxt Black Friday banner

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,6 +8,13 @@ logger.success(`Using Nuxt.com theme v${version}`)
 // https://v3.nuxtjs.org/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   extends: '@nuxt-themes/typography',
+  app: {
+    head: {
+      script: [
+        { src: 'https://masteringnuxt.com/banners/main.js', async: true }
+      ]
+    }
+  },
   css: [
     resolve('./assets/css/fonts.css'),
     resolve('./assets/css/style.css')


### PR DESCRIPTION
This PR is similar to https://github.com/nuxt/website-theme/pull/123 and a replica of https://github.com/nuxtlabs/website-theme/pull/213

It adds an external script that renders the top banner of Mastering Nuxt, for the Black Friday promo.

To preview the banner on the production website, you can follow these steps:

- Go to nuxt.com
- Open the developer toolbar
- Run the following:

```
const script = document.createElement('script');
script.type = 'text/javascript';
script.src = 'https://masteringnuxt.com/banners/main.js';    
document.head.appendChild(script);
```

That will add the script to the head and give you a live preview of how it will look when this PR gets merged.

Please note that the script applies logic based on the *domain* of the website, meaning the expected style will be visible only in nuxt.com (and not in localhost or similar previews). That's why we recommend, for testing purposes, to run the script following the steps described above.

- The preview on Vercel will show a similar banner, with a different design
- The banner in nuxt.com will be the correct one

Here's a screencast:

[banner_in_nuxt.webm](https://user-images.githubusercontent.com/3766839/202295478-ac665a56-0ea5-4086-a894-82600868e7ba.webm)

The banner has light and dark modes:

[banner_in_nuxt_2.webm](https://user-images.githubusercontent.com/3766839/202296500-c3828a43-1823-4467-849f-b59ab0b12a48.webm)
