### PR TITLE
refactor(homecompaniescarousel): refactor homecompaniescarousel for accessibility

### DIFF
--- a/components/content/home/HomeCompaniesCarousel.vue
+++ b/components/content/home/HomeCompaniesCarousel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative mt-20" aria-hidden="true" inert>
+  <div class="relative mt-20" aria-hidden="true">
     <div class="overflow-hidden">
       <div class="slider">
         <div class="slide-track mb-2 sm:mb-8 animation">


### PR DESCRIPTION
fixed by adding `tabindex="-1"` to links and `aria-hidden="true" inert` to root div adding `tabindex="-1"` to root div does not work in firefox

resolves #1085 