### PR TITLE
fix: update prose vertical margin

### DIFF
--- a/tokens.config.ts
+++ b/tokens.config.ts
@@ -189,6 +189,9 @@ export default defineTheme({
     }
   },
   typography: {
+    verticalMargin: {
+      base: '16px'
+    },
     color: {
       primary: {
         50: '#d6ffee',


### PR DESCRIPTION
Following @Atinux discussion. Updated `typography.verticalMargin` token