### PR TITLE
feat(css): improve anchor scroll

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -14,8 +14,10 @@ a:focus {
   @apply relative px-4 sm:px-6 lg:px-8;
 }
 
-h1,h2,h3 {
-  @apply scroll-mt-16;
+.docs-page {
+  h1, h2, h3 {
+    @apply scroll-mt-20;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
Hi :wave: this adds a scroll margin top to every `h1` `h2` and `h3`. 
This would make the scroll to anchor taking into account the navbar's height

A better explanation with some images: 
![image](https://user-images.githubusercontent.com/63512348/224414139-28165678-cc62-4010-9930-7815f354b799.png)

![image](https://user-images.githubusercontent.com/63512348/224414083-a3c5b26f-31f8-4716-9cdb-e497505b06eb.png)