### PR TITLE
fix: themeselect as client-only

### DIFF
--- a/components/ThemeSelect.vue
+++ b/components/ThemeSelect.vue
@@ -1,13 +1,16 @@
 <template>
-  <AppToggle
-    v-model="isDark"
-    name="theme"
-    icon-on="uil:moon"
-    icon-off="uil:sun"
-    class="theme-select"
-  >
-    <span class="sr-only">Toggle theme</span>
-  </AppToggle>
+  <ColorScheme>
+    <AppToggle
+      v-model="isDark"
+      name="theme"
+      icon-on="uil:moon"
+      icon-off="uil:sun"
+      class="theme-select"
+      v-bind="$attrs"
+    >
+      <span class="sr-only">Toggle theme</span>
+    </AppToggle>
+  </ColorScheme>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
Theme toggle was not showing correctly on launch.

https://color-mode.nuxtjs.org/#caveats

If you are getting TS warnings, it may be related to this issue:
https://github.com/nuxt-modules/color-mode/issues/168