### PR TITLE
Add Mastering Nuxt banner

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -52,6 +52,13 @@ export default defineNuxtConfig({
     }
   },
   extends: '@nuxt-themes/typography',
+  app: {
+    head: {
+      script: [
+        { src: 'https://masteringnuxt.com/banner.js?affiliate=nuxt&type=top', async: true }
+      ]
+    }
+  },
   css: [
     resolve('./assets/css/fonts.css'),
     resolve('./assets/css/style.css'),


### PR DESCRIPTION
This PR is similar to https://github.com/nuxt/nuxt.com/pull/1027

It adds an external script that renders the top banner of Mastering Nuxt at the top of the site.

To preview the banner on the production website, you can follow these steps:

- Go to nuxt.com
- Open the developer toolbar
- Run the following:

```
const script = document.createElement('script');
script.type = 'text/javascript';
script.src = 'https://masteringnuxt.com/banner.js?affiliate=nuxt&type=top';    
document.head.appendChild(script);
```

That will add the script to the head and give you a live preview of how it will look when this PR gets merged.

![image](https://user-images.githubusercontent.com/3766839/226623890-f6633605-ba14-4f61-89f5-f253d7105827.png)

Let me know if you have comments or questions.