### PR TITLE
chore: typo in footer links

### DIFF
--- a/composables/useNavigation.ts
+++ b/composables/useNavigation.ts
@@ -122,7 +122,7 @@ const _useNavigation = () => {
       to: 'https://content.nuxt.com/',
       target: '_blank'
     }, {
-      label: 'Nuxt Devtools',
+      label: 'Nuxt DevTools',
       to: 'https://devtools.nuxt.com/',
       target: '_blank'
     }, {


### PR DESCRIPTION
changed 'Devtools' to 'DevTools'.