### PR TITLE
docs: corrected typo on the 3.8 release notes

### DIFF
--- a/content/5.blog/17.v3-8.md
+++ b/content/5.blog/17.v3-8.md
@@ -29,7 +29,7 @@ Read the Nuxt CLI `v3.9.0` release notes.
 
 ### ✨ Built-in Nuxt DevTools
 
-Nuxt DevTools v1.0.0 is outo and we now think it's ready to be shipped as a direct dependency of Nuxt.
+Nuxt DevTools v1.0.0 is out and we now think it's ready to be shipped as a direct dependency of Nuxt.
 
 ::read-more{to="https://github.com/nuxt/devtools/releases/tag/v1.0.0" icon="i-simple-icons-github" color="gray"}
 Check out the `v1.0.0` release notes of Nuxt Devtools.


### PR DESCRIPTION
This corrects a small typo on the 3.8 release notes.