### PR TITLE
fix(enterprise): prevent support icon from shrinking

### DIFF
--- a/components/content/enterprise/support/EnterpriseSupportListItem.vue
+++ b/components/content/enterprise/support/EnterpriseSupportListItem.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 <template>
   <div class="flex flex-col sm:flex-row items-center gap-4 mb-8">
-    <div class="w-14 h-14 bg-gray-100 dark:bg-gray-800 ring-1 ring-gray-300 dark:ring-gray-700 rounded-md flex items-center justify-center">
+    <div class="w-14 h-14 bg-gray-100 dark:bg-gray-800 ring-1 ring-gray-300 dark:ring-gray-700 rounded-md flex shrink-0 items-center justify-center">
       <UIcon :name="icon" class="w-8 h-8" />
     </div>
 


### PR DESCRIPTION
### What change does this PR introduce?

Resolves #1399 

This PR fixes the icon shrinking issue on enterprise support page. Icon was breaking below 900 px width and in tablet view(768px). Now it won't shrink and work fine from mobile to desktop.

**BEFORE THE FIX:** 

![nuxt com_enterprise_support](https://github.com/nuxt/nuxt.com/assets/85216180/dcf6a335-e188-4b9b-b765-5d3980e9b388)

**AFTER THE FIX:**

![localhost_3000_enterprise_support](https://github.com/nuxt/nuxt.com/assets/85216180/7fc817f9-7c59-4c26-952e-cb70e5802aae)
