### PR TITLE
fix(enterprise): spacing adjustment for badges

### DIFF
--- a/pages/enterprise/jobs.vue
+++ b/pages/enterprise/jobs.vue
@@ -47,15 +47,16 @@ await fetchList()
           </template>
 
           <template #footer>
-            <UBadge
-              v-for="location of job.locations"
-              :key="location"
-              :label="location"
-              size="lg"
-              variant="subtle"
-              class="mr-3"
-            />
-            <UBadge :label="job.remote" size="lg" variant="subtle" />
+            <div class="flex flex-wrap gap-3">
+              <UBadge
+                v-for="location of job.locations"
+                :key="location"
+                :label="location"
+                size="lg"
+                variant="subtle"
+              />
+              <UBadge :label="job.remote" size="lg" variant="subtle" />
+            </div>
           </template>
         </UPageCard>
       </UPageBody>


### PR DESCRIPTION
### What change does this PR introduce?

Fixes #1403

This PR fixes the spacing issue for location badges on the 'Enterprise Jobs' page.

| **BEFORE** | **AFTER** | 
|-------- | ------ | 
| ![nuxt com_enterprise_jobs](https://github.com/nuxt/nuxt.com/assets/85216180/582b8a33-8be3-429d-a968-2381f4d6a980)  | ![localhost_3000_enterprise_jobs](https://github.com/nuxt/nuxt.com/assets/85216180/94c2b795-3117-4a2c-90cf-c2a51e3e0f54) |