### PR TITLE
fix(home): broken testimonials cards on Safari

### DIFF
--- a/components/home/HomeSectionTestimonials.vue
+++ b/components/home/HomeSectionTestimonials.vue
@@ -25,6 +25,7 @@ defineProps<{
           background: 'dark:bg-gray-900/50'
         }
       }"
+      class="break-inside-avoid"
       :to="testimonial.author.url"
       target="_blank"
     >

--- a/components/home/HomeSectionTestimonials.vue
+++ b/components/home/HomeSectionTestimonials.vue
@@ -15,42 +15,45 @@ defineProps<{
 
 <template>
   <UPageColumns>
-    <UPageCard
+    <div
       v-for="(testimonial, index) in testimonials"
       :key="index"
-      :ui="{
-        background: 'dark:bg-gradient-to-b from-gray-700/50 to-gray-900/50',
-        body: {
-          base: 'flex-1',
-          background: 'dark:bg-gray-900/50'
-        }
-      }"
-      class="break-inside-avoid"
-      :to="testimonial.author.url"
-      target="_blank"
+      class="break-inside-avoid py-0.5"
     >
-      <q class="italic text-lg text-gray-500 dark:text-gray-400">
-        {{ testimonial.quote }}
-      </q>
+      <UPageCard
+        :ui="{
+          background: 'dark:bg-gradient-to-b from-gray-700/50 to-gray-900/50',
+          body: {
+            base: 'flex-1',
+            background: 'dark:bg-gray-900/50',
+          }
+        }"
+        :to="testimonial.author.url"
+        target="_blank"
+      >
+        <q class="italic text-lg text-gray-500 dark:text-gray-400">
+          {{ testimonial.quote }}
+        </q>
 
-      <div class="flex gap-x-4 items-center mt-6">
-        <UAvatar
-          :src="testimonial.author.imgSrc"
-          :srcset="testimonial.author.imgSrcSet"
-          loading="lazy"
-          :alt="testimonial.author.name"
-          size="md"
-          :ui="{ rounded: 'rounded-lg' }"
-        />
-        <div class="min-w-0">
-          <p class="font-semibold text-primary">
-            {{ testimonial.author.name }}
-          </p>
-          <p class="text-sm truncate">
-            {{ testimonial.author.job }}
-          </p>
+        <div class="flex gap-x-4 items-center mt-6">
+          <UAvatar
+            :src="testimonial.author.imgSrc"
+            :srcset="testimonial.author.imgSrcSet"
+            loading="lazy"
+            :alt="testimonial.author.name"
+            size="md"
+            :ui="{ rounded: 'rounded-lg' }"
+          />
+          <div class="min-w-0">
+            <p class="font-semibold text-primary">
+              {{ testimonial.author.name }}
+            </p>
+            <p class="text-sm truncate">
+              {{ testimonial.author.job }}
+            </p>
+          </div>
         </div>
-      </div>
-    </UPageCard>
+      </UPageCard>
+    </div>
   </UPageColumns>
 </template>


### PR DESCRIPTION
In Safari (v16.5.2) the homepage testimonials are getting cut off in their columns:

![Screenshot 2023-11-03 at 17 09 52](https://github.com/nuxt/nuxt.com/assets/11662791/b2b66c9b-855f-4316-a6bd-b7e056c7f8e5)

Added the "break-inside-avoid" tailwind class to remedy this.

Hope this helps 🙏