### PR TITLE
feat(modules): add copy modules's npm button

### DIFF
--- a/pages/modules/index.vue
+++ b/pages/modules/index.vue
@@ -131,11 +131,11 @@ const { copy } = useCopyToClipboard()
               <span class="line-clamp-2">{{ module.description }}</span>
             </template>
 
-            <UTooltip class="absolute top-6 right-6 group-hover:opacity-100 opacity-0 transition" :text="`Copy “${module.npm}”`">
+            <UTooltip class="hidden lg:inline-flex absolute top-6 right-6 group-hover:opacity-100 opacity-0 transition" :text="`Copy install command`">
               <UButton
                 icon="i-ph-package-duotone"
                 color="white"
-                @click="copy(module.npm, { title: 'Copied to clipboard' })"
+                @click="copy(`npx nuxi@latest modules add ${module.name}`, { title: 'Command copied to clipboard:', description: `npx nuxi@latest modules add ${module.name}` })"
               />
             </UTooltip>
 

--- a/pages/modules/index.vue
+++ b/pages/modules/index.vue
@@ -42,6 +42,8 @@ defineShortcuts({
     inputRef.value.input.focus()
   }
 })
+
+const { copy } = useCopyToClipboard()
 </script>
 
 <template>
@@ -128,6 +130,14 @@ defineShortcuts({
             <template #description>
               <span class="line-clamp-2">{{ module.description }}</span>
             </template>
+
+            <UTooltip class="absolute top-6 right-6 group-hover:opacity-100 opacity-0 transition" :text="`Copy “${module.npm}”`">
+              <UButton
+                icon="i-ph-package-duotone"
+                color="white"
+                @click="copy(module.npm, { title: 'Copied to clipboard' })"
+              />
+            </UTooltip>
 
             <template #footer>
               <div class="flex items-center justify-between gap-3 -my-1 text-gray-600 dark:text-gray-300">


### PR DESCRIPTION
this feature will help user to copy the module's npm name easier, I though it's a good idea to have

https://github.com/nuxt/nuxt.com/assets/38922203/c0951553-4304-4128-ad07-b3986e624a5e
