### PR TITLE
fix: prevent font flickering on first visit or hard refresh

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -122,6 +122,7 @@ export default defineNuxtConfig({
   googleFonts: {
     display: 'swap',
     download: true,
+    base64: true,
     families: {
       'DM+Sans': [400, 500, 600, 700]
     }


### PR DESCRIPTION
This fix adds the `base64` option to the `googleFonts` section in the nuxt config. This is to prevent the font-flickering behavior (due to swap) that happens on first visit or when hard refresh is done. One trade-off of adding this option is the size of the base64-injected CSS file that's automatically generated (which is ~690kb on the dev server).

Just wanted to send this out there if you think that trade-off is worth the first-time impression of visitors, or whether you think the visual font swap behavior would affect that impression at all.

Fyi the font-flickering behavior looks like this:

https://github.com/nuxt/nuxt.com/assets/16872027/7dd401cd-02b0-4254-b599-eae2c35b8abb
