### PR TITLE
chore(modules): update modules key

### DIFF
--- a/pages/modules/index.vue
+++ b/pages/modules/index.vue
@@ -108,8 +108,8 @@ const { copy } = useCopyToClipboard()
 
         <UPageGrid v-if="filteredModules?.length">
           <UPageCard
-            v-for="(module, index) in filteredModules"
-            :key="index"
+            v-for="module in filteredModules"
+            :key="module.name"
             :to="`/modules/${module.name}`"
             :title="module.name"
             class="flex flex-col"


### PR DESCRIPTION
one of the tips from `Daniel Kelly` is to use not `index` as key, and I think this might fix the problem with module's image when you go to a url with `category` query

example:
[https://nuxt.com/modules?category=Analytics](https://nuxt.com/modules?category=Analytics) icons are not correct

**it didn't help the issue so I close it, sorry :)**