### PR TITLE
fix: normalize paths to allow run dev server on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist
 # Local editor
 .vscode/
 *.code-workspace
+.idea/

--- a/README.md
+++ b/README.md
@@ -34,17 +34,6 @@ echo %cd%
 
 Copy the output of the command above and paste it in the `NUXT_DOCS_PATH` variable in the `.env` file.
 
-If you are on Windows, you need to add `file:///` prefix and replace `\` with `/` in the path, for example:
-```.env
-NUXT_DOCS_PATH=file:///C:/work/nuxt-org/nuxt.com
-```
-
-where the root folder is `C:\work\nuxt-org\nuxt.com`:
-```shell
-C:\work\nuxt-org\nuxt.com>echo %cd%
-C:\work\nuxt-org\nuxt.com
-```
-
 ## Development
 
 Start the development server:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,24 @@ Clone/Fork [nuxt/nuxt](https://github.com/nuxt/nuxt) repo where you want (but no
 pwd
 ```
 
+If you are on Windows, you can use the following command instead:
+
+```bash
+echo %cd%
+```
+
 Copy the output of the command above and paste it in the `NUXT_DOCS_PATH` variable in the `.env` file.
+
+If you are on Windows, you need to add `file:///` prefix and replace `\` with `/` in the path, for example:
+```.env
+NUXT_DOCS_PATH=file:///C:/work/nuxt-org/nuxt.com
+```
+
+where the root folder is `C:\work\nuxt-org\nuxt.com`:
+```shell
+C:\work\nuxt-org\nuxt.com>echo %cd%
+C:\work\nuxt-org\nuxt.com
+```
 
 ## Development
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,21 @@
 import { ofetch } from 'ofetch'
 import { logger } from '@nuxt/kit'
+import { isWindows } from 'std-env'
+
+function normalizedDirPath (path: string) {
+  if (!path || !isWindows) {
+    return path
+  }
+
+  const windowsPath = path.replace(/\\/g, '/')
+  if (!windowsPath.startsWith('file:///'))
+    return `file:///${windowsPath}`
+
+  return windowsPath
+}
+
+const docsSourceBase = normalizedDirPath(process.env.NUXT_DOCS_PATH)
+const examplesSourceBase = normalizedDirPath(process.env.NUXT_EXAMPLES_PATH)
 
 const docsSource: any = {
   name: 'nuxt-docs',
@@ -10,9 +26,9 @@ const docsSource: any = {
   prefix: '/1.docs',
   token: process.env.NUXT_GITHUB_TOKEN || ''
 }
-if (process.env.NUXT_DOCS_PATH) {
+if (docsSourceBase) {
   docsSource.driver = 'fs'
-  docsSource.base = process.env.NUXT_DOCS_PATH
+  docsSource.base = docsSourceBase
 }
 
 const examplesSource: any = {
@@ -24,9 +40,9 @@ const examplesSource: any = {
   prefix: '/docs/4.examples',
   token: process.env.NUXT_GITHUB_TOKEN || ''
 }
-if (process.env.NUXT_EXAMPLES_PATH) {
+if (examplesSourceBase) {
   examplesSource.driver = 'fs'
-  examplesSource.base = process.env.NUXT_EXAMPLES_PATH
+  examplesSource.base = examplesSourceBase
 }
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
@@ -44,8 +60,8 @@ export default defineNuxtConfig({
     '@vueuse/nuxt',
     'nuxt-og-image',
     () => {
-      if (process.env.NUXT_DOCS_PATH) { logger.success(`Using local Nuxt docs from ${process.env.NUXT_DOCS_PATH}`) }
-      if (process.env.NUXT_EXAMPLES_PATH) { logger.success(`Using local Nuxt examples from ${process.env.NUXT_EXAMPLES_PATH}`) }
+      if (docsSourceBase) { logger.success(`Using local Nuxt docs from ${docsSourceBase}`) }
+      if (examplesSourceBase) { logger.success(`Using local Nuxt examples from ${examplesSourceBase}`) }
     }
   ],
   routeRules: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,7 +2,7 @@ import { ofetch } from 'ofetch'
 import { logger } from '@nuxt/kit'
 import { isWindows } from 'std-env'
 
-function normalizedDirPath (path: string) {
+function normalizedDirPath (path?: string) {
   if (!path || !isWindows) {
     return path
   }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,10 +8,7 @@ function normalizedDirPath (path: string) {
   }
 
   const windowsPath = path.replace(/\\/g, '/')
-  if (!windowsPath.startsWith('file:///'))
-    return `file:///${windowsPath}`
-
-  return windowsPath
+  return windowsPath.startsWith('file:///') ? windowsPath : `file:///${windowsPath}`
 }
 
 const docsSourceBase = normalizedDirPath(process.env.NUXT_DOCS_PATH)

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "perfect-debounce": "^1.0.0",
     "scule": "^1.0.0",
     "sitemap": "^7.1.1",
+    "std-env": "^3.4.3",
     "ufo": "^1.3.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ dependencies:
   sitemap:
     specifier: ^7.1.1
     version: 7.1.1
+  std-env:
+    specifier: ^3.4.3
+    version: 3.4.3
   ufo:
     specifier: ^1.3.1
     version: 1.3.1


### PR DESCRIPTION
This PR also includes:
- add Windows instructions to setup section
- add `.idea/` folder (JetBrains IDE) to `.gitignore`

![imagen](https://github.com/nuxt/nuxt.com/assets/6311119/245fa10a-0c09-4ffc-a059-83bab7904fe5)
