### PR TITLE
fix: configure tooltip `popper` as absolute

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -77,7 +77,10 @@ export default defineAppConfig({
       rounded: 'rounded-xl'
     },
     tooltip: {
-      background: '!bg-background'
+      background: '!bg-background',
+      popper: {
+        strategy: 'absolute'
+      }
     },
     // `@nuxt/ui-pro` specific
     variables: {


### PR DESCRIPTION
# same as 197ea75 commit

## before
<img width="1263" alt="2023-11-14 12 57 55" src="https://github.com/nuxt/nuxt.com/assets/133459587/f6774c41-3da9-41da-8757-aa66a3fe26f3">

## after
<img width="1435" alt="2023-11-14 13 48 29" src="https://github.com/nuxt/nuxt.com/assets/133459587/26c08f61-d27c-46fd-a8ba-278096831f45">
