### PR TITLE
fix: homesection's background color in lightmode

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -77,7 +77,10 @@ export default defineAppConfig({
       rounded: 'rounded-xl'
     },
     tooltip: {
-      background: '!bg-background'
+      background: '!bg-background',
+      popper: {
+        strategy: 'absolute'
+      }
     },
     // `@nuxt/ui-pro` specific
     variables: {

--- a/content/0.index.yml
+++ b/content/0.index.yml
@@ -13,7 +13,7 @@ logos:
 sections:
   - title: 'The power of<br><span class="text-primary">Vue Components</span>'
     description: 'We love Vue Single-File Components as much as you do. Simple, intuitive and powerful, Nuxt lets you write Vue components in a way that makes sense. Every repetitive task is automated, so you can focus on writing your full-stack Vue application with confidence.'
-    class: 'dark bg-gray-900'
+    class: 'dark:bg-gray-900'
     align: left
     links:
       - label: 'Learn about Views'
@@ -53,7 +53,7 @@ sections:
       ```
   - title: 'Static or Dynamic,<br><span class="text-primary">the choice is yours</span>'
     description: 'Decide what rendering strategy you need at the route level. By leveraging the hybrid rendering, you can get the best of both worlds: the performance of a static site and the interactivity of a dynamic one.'
-    class: 'dark bg-gray-900'
+    class: 'dark:bg-gray-900'
     align: right
     links:
       - label: 'Learn about Hybrid Rendering'
@@ -157,7 +157,7 @@ sections:
         to: '/docs/guide/concepts/typescript'
   - title: 'Ship faster with<br><span class="text-primary">endless integrations</span>'
     description: 'Integrate with your favorite tools and services. Nuxt is built to be flexible and can be extended with a robust modules ecosystem. Connect your application with popular headless CMS, eCommerce, Database or UI/UX libraries with a single line of code.'
-    class: 'dark bg-gray-900 dark:!bg-gradient-to-b from-gray-950 to-gray-900'
+    class: 'dark:bg-gray-900 dark:!bg-gradient-to-b from-gray-950 to-gray-900'
     align: left
     links:
       - label: 'Explore Nuxt Modules'
@@ -234,7 +234,7 @@ sections:
         to: /modules/algolia
   - title: 'Built by developers<br><span class="text-primary">around the world.</span>'
     description: 'The development of Nuxt and its ecosystem is led by an international team. From contributors to developer advocates, the community is made up of members with different horizons and skills. We are happy to see new members every day and encourage anyone to join us and help in many ways: answering questions, giving a talk, creating modules and contributing to the core.'
-    class: 'dark bg-gray-900'
+    class: 'dark:bg-gray-900'
     align: right
     slot: contributors
     links:


### PR DESCRIPTION
The background color of the partial homesection remains the same in light mode as it does in dark mode, failing to adapt to the theme color change. This results in a significant disconnect, especially in light mode. 💗

- before:
<img width="1258" alt="light-mode-before" src="https://github.com/nuxt/nuxt.com/assets/133459587/ca34c982-d166-4ff1-981d-b2708971f0fc">

- after:
<img width="1247" alt="light-mode-after" src="https://github.com/nuxt/nuxt.com/assets/133459587/a9ec1494-047b-4b0e-82db-902da8952510">
