### PR TITLE
chore: fix broken link

### DIFF
--- a/content/7.blog/18.nuxt-devtools-v1-0.md
+++ b/content/7.blog/18.nuxt-devtools-v1-0.md
@@ -30,7 +30,7 @@ export default defineNuxtConfig({
 
 Over the recent years, there has been an increasing focus on Developer Experience (DX). Tools and frameworks have been striving to improve the DX. Along the way, Nuxt introduced many innovative features and conventions to make your day-to-day development easier and more efficient.
 
-For example, [file-based routing](/docs/guide/directory-structure/pages), [layout system](/docs/guide/directory-structure/layouts), [plugins](/docs/guide/directory-structure/plugins), [route middleware](/docs/guide/directory-structure/middleware), [composables auto-import](/docs/guide/concepts/auto-imports), [file-based server APIs](https://nitro.unjs.io/guide/introduction/routing), [powerful module system](/modules) and many more.
+For example, [file-based routing](/docs/guide/directory-structure/pages), [layout system](/docs/guide/directory-structure/layouts), [plugins](/docs/guide/directory-structure/plugins), [route middleware](/docs/guide/directory-structure/middleware), [composables auto-import](/docs/guide/concepts/auto-imports), [file-based server APIs](https://nitro.unjs.io/guide/routing), [powerful module system](/modules) and many more.
 
 ![List of Nuxt features that enhance developer experience](/assets/blog/devtools/slide-dx.png){.border.border-gray-200.dark:border-gray-700.rounded-lg}
 


### PR DESCRIPTION
Fix broken link to UnJS Nitro docs