### PR TITLE
docs(deploy): add Cloudflare Pages route matching

### DIFF
--- a/content/3.deploy/cloudflare.md
+++ b/content/3.deploy/cloudflare.md
@@ -39,6 +39,7 @@ export default defineNuxtConfig({
     prerender: {
       autoSubfolderIndex: false
     }
+  }
 })
 ```
 

--- a/content/3.deploy/cloudflare.md
+++ b/content/3.deploy/cloudflare.md
@@ -29,7 +29,9 @@ To statically generate your website, set the build command to: `nuxt generate`
 
 ### Route matching
 
-For statically generated sites use the nitro option `autoSubfolderIndex` to adapt Cloudflare [route matching](https://developers.cloudflare.com/pages/configuration/serving-pages/#route-matching) rules.
+On CloudFlare Pages, if an HTML file is found with a matching path to the current route requested, it will serve it. It will also redirect HTML pages to their extension-less counterparts: for instance, `/contact.html` will be redirected to `/contact`, and `/about/index.html` will be redirected to `/about/`.
+
+To match Cloudflare [route matching](https://developers.cloudflare.com/pages/configuration/serving-pages/#route-matching) rules, set the nitro option `autoSubfolderIndex` to `false`.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/content/3.deploy/cloudflare.md
+++ b/content/3.deploy/cloudflare.md
@@ -27,6 +27,19 @@ To leverage sever-side rendering on the edge, set the build command to: `nuxt bu
 
 To statically generate your website, set the build command to: `nuxt generate`
 
+### Route matching
+
+For statically generated sites use the nitro option `autoSubfolderIndex` to adapt Cloudflare [route matching](https://developers.cloudflare.com/pages/configuration/serving-pages/#route-matching) rules.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    prerender: {
+      autoSubfolderIndex: false
+    }
+})
+```
+
 ### Direct Upload
 
 Alternatively, you can use [wrangler](https://github.com/cloudflare/workers-sdk) to upload your project to Cloudflare.


### PR DESCRIPTION
Cloudflare Pages route matching is:
	`/contact.html` redirected to `/contact`
	`/about/index.html` redirected to `/about/`

For statically generated sites, use the nitro option `autoSubfolderIndex` to disable auto generated subfolder.

```ts
defineNuxtConfig({
  nitro: {
    prerender: {
      autoSubfolderIndex: false
    }
})
```

more discussion about this, refer to https://github.com/nuxt/nuxt/issues/22254#issuecomment-1729410570