### PR TITLE
Update Vue 3.4 changelog link

### DIFF
--- a/content/7.blog/19.v3-9.md
+++ b/content/7.blog/19.v3-9.md
@@ -23,7 +23,7 @@ This comes with a whole host of great improvements and bug fixes - check out [th
 
 ### ✨ Vue 3.4 ready
 
-This release is tested with the latest Vue 3.4 release candidate, and has the necessary configuration to take advantage of [new features in Vue 3.4](https://gist.github.com/yyx990803/061593abfbaf1f2e3ddeee9094a6e6bf), including debugging hydration errors in production (just set `debug: true`) in your Nuxt config.
+This release is tested with the latest Vue 3.4 release candidate, and has the necessary configuration to take advantage of [new features in Vue 3.4](https://blog.vuejs.org/posts/vue-3-4), including debugging hydration errors in production (just set `debug: true`) in your Nuxt config.
 
 👉 To take advantage, just update your `vue` version once v3.4 is released, or try out the release candidate today:
 


### PR DESCRIPTION
Vue released a [blog post](https://blog.vuejs.org/posts/vue-3-4) announcing version 3.4. After reading it over, I believe it is a better guide for migrating than the Gist that was previously linked.