### PR TITLE
perf: improve css render performance

### DIFF
--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -4,6 +4,8 @@ const { footerLinks } = useNavigation()
 
 <template>
   <UFooter
+    class="content-visibility contain-content"
+    style="contain-intrinsic-size: auto 100px"
     :ui="{
       bottom: { wrapper: 'border-t border-gray-200 dark:border-gray-800', container: '!py-6' },
       top: { wrapper: 'border-t border-gray-200 dark:border-gray-800', container: 'py-8 lg:py-12' }

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -24,7 +24,7 @@ defineProps<{
 </script>
 
 <template>
-  <UHeader :links="links">
+  <UHeader :links="links" class="contain-layout">
     <template #logo>
       <Logo class="block w-auto h-6" @click.right.prevent="$router.push('/design-kit')" />
     </template>

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -78,7 +78,7 @@ function copyLink () {
             variant="ghost"
             class="-my-1.5 -mx-2.5"
           >
-            <UAvatar :src="author.avatarUrl" :alt="author.name" />
+            <UAvatar loading="lazy" :src="author.avatarUrl" :alt="author.name" />
 
             <div class="text-left">
               <p class="font-medium">

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -99,6 +99,7 @@ await fetchList()
                     :key="subIndex"
                     :src="author.avatarUrl"
                     :alt="author.name"
+                    loading="lazy"
                     class="lg:hover:scale-110 lg:hover:ring-primary-500 dark:lg:hover:ring-primary-400 transition-transform"
                   >
                     <NuxtLink v-if="author.link" :to="author.link" target="_blank" class="focus:outline-none" tabindex="-1">

--- a/pages/enterprise/jobs.vue
+++ b/pages/enterprise/jobs.vue
@@ -43,7 +43,7 @@ await fetchList()
           }"
         >
           <template #icon>
-            <UAvatar :src="job.organization.avatar" size="lg" />
+            <UAvatar loading="lazy" :src="job.organization.avatar" size="lg" />
           </template>
 
           <template #footer>

--- a/pages/enterprise/sponsors.vue
+++ b/pages/enterprise/sponsors.vue
@@ -51,7 +51,7 @@ defineOgImage({
                 :to="sponsor.sponsorUrl"
                 target="_blank"
               >
-                <UAvatar :src="sponsor.sponsorLogo" :alt="sponsor.sponsorName" class="mx-auto mt-4" size="2xl" />
+                <UAvatar loading="lazy"  :src="sponsor.sponsorLogo" :alt="sponsor.sponsorName" class="mx-auto mt-4" size="2xl" />
                 <h3 class="mt-6 font-semibold leading-7 tracking-tight text-gray-900 dark:text-white mb-2">
                   {{ sponsor.sponsorName }}
                 </h3>
@@ -59,7 +59,7 @@ defineOgImage({
             </div>
             <div v-else class="flex flex-wrap gap-8 ml-12">
               <NuxtLink v-for="(sponsor, index) in value" :key="index" :to="sponsor.sponsorUrl" target="_blank" class="inline-flex">
-                <UAvatar :src="sponsor.sponsorLogo" :alt="sponsor.sponsorName" size="lg" />
+                <UAvatar loading="lazy" :src="sponsor.sponsorLogo" :alt="sponsor.sponsorName" size="lg" />
               </NuxtLink>
             </div>
           </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -111,7 +111,8 @@ span[class^="i-ph"] {
       v-for="(section, index) of page.sections"
       :key="index"
       :slot="section.slot"
-      :class="section.class.toString() + ' content-visibility contain-intrinsic-size-500'"
+      :class="section.class"
+      class="content-visibility contain-intrinsic-size-500"
       :align="section.align"
       :links="section.links"
     >

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,7 +16,41 @@ useSeoMeta({
   twitterImage: joinURL(site.url, '/new-social.jpg')
 })
 </script>
+<style>
+.content-visibility-auto {
+  content-visibility: auto;
+  contain:layout;
+}
+.contain-intrinsic-size-200 {
+  contain-intrinsic-size: 200px;
+}
+.contain-intrinsic-size-500 {
+  contain-intrinsic-size: 200px;
+}
+.contain-intrinsic-size-800 {
+  contain-intrinsic-size: 200px;
+}
 
+.contain-layout{
+  contain:layout;
+}
+.contain-content{
+  contain:content;
+}
+.contain-strict{
+  contain:strict;
+}
+
+img, svg, span[class^="i-ph"] {
+  contain:content;
+}
+
+span[class^="i-ph"] {
+  content-visibility: auto;
+  contain-intrinsic-size: 20px;
+}
+
+</style>
 <template>
   <div v-if="page">
     <ULandingHero :ui="{ base: 'relative z-[1]' }" class="dark:bg-gradient-to-b from-gray-950 to-gray-900">
@@ -77,7 +111,7 @@ useSeoMeta({
       v-for="(section, index) of page.sections"
       :key="index"
       :slot="section.slot"
-      :class="section.class"
+      :class="section.class.toString() + ' content-visibility contain-intrinsic-size-500'"
       :align="section.align"
       :links="section.links"
     >

--- a/pages/modules/[slug].vue
+++ b/pages/modules/[slug].vue
@@ -91,6 +91,7 @@ defineOgImage({
             :icon="moduleIcon(module.category)"
             :alt="module.name"
             size="lg"
+            loading="lazy"
             :ui="{ rounded: 'rounded-lg' }"
             class="-m-[4px]"
           />
@@ -139,7 +140,7 @@ defineOgImage({
 
         <div v-for="(maintainer, index) in module.maintainers" :key="maintainer.github" class="flex items-center gap-3">
           <NuxtLink :to="`https://github.com/${maintainer.github}`" target="_blank" class="flex items-center gap-1.5 hover:text-primary">
-            <UAvatar :src="`https://ipx.nuxt.com/f_auto,s_20x20/gh_avatar/${maintainer.github}`" :srcset="`https://ipx.nuxt.com/f_auto,s_40x40/gh_avatar/${maintainer.github} 2x`" :alt="maintainer.github" size="2xs" />
+            <UAvatar loading="lazy" :src="`https://ipx.nuxt.com/f_auto,s_20x20/gh_avatar/${maintainer.github}`" :srcset="`https://ipx.nuxt.com/f_auto,s_40x40/gh_avatar/${maintainer.github} 2x`" :alt="maintainer.github" size="2xs" />
             <span class="text-sm font-medium">{{ maintainer.github }}</span>
           </NuxtLink>
 

--- a/pages/modules/index.vue
+++ b/pages/modules/index.vue
@@ -45,6 +45,29 @@ defineShortcuts({
 
 const { copy } = useCopyToClipboard()
 </script>
+<style>
+#module-categories {
+  contain: content;
+  content-visibility: auto;
+  height: 643px;
+  contain-intrinsic-size: 643px;
+}
+
+.module-card {
+  contain: content;
+  content-visibility: auto;
+}
+
+@media screen and (max-width: 992px) {
+  .module-card {
+    contain-intrinsic-size: auto 200px;
+  }
+}
+
+.module-card {
+  contain-intrinsic-size: auto 238px;
+}
+</style>
 
 <template>
   <UContainer>
@@ -53,22 +76,22 @@ const { copy } = useCopyToClipboard()
         <UPageGrid :ui="{ wrapper: 'grid-cols-2 sm:grid-cols-2 xl:grid-cols-2 gap-4' }">
           <UPageCard to="https://image.nuxt.com/?utm_source=nuxt_website&utm_medium=modules" target="_blank" description="Plug-and-play image optimization.">
             <template #title>
-              Nuxt Image <UIcon name="i-ph-medal-duotone" class="h-4 w-4 text-primary pointer-events-none" />
+              Nuxt Image <UIcon loading="lazy" name="i-ph-medal-duotone" class="h-4 w-4 text-primary pointer-events-none" />
             </template>
           </UPageCard>
           <UPageCard to="https://content.nuxt.com/?utm_source=nuxt_website&utm_medium=modules" target="_blank" title="Nuxt Content" description="Git-based CMS with Markdown support.">
             <template #title>
-              Nuxt Content <UIcon name="i-ph-medal-duotone" class="h-4 w-4 text-primary pointer-events-none" />
+              Nuxt Content <UIcon loading="lazy" name="i-ph-medal-duotone" class="h-4 w-4 text-primary pointer-events-none" />
             </template>
           </UPageCard>
           <UPageCard to="https://devtools.nuxt.com/?utm_source=nuxt_website&utm_medium=modules" target="_blank" description="Visual tools that help you to know your app.">
             <template #title>
-              Nuxt DevTools <UIcon name="i-ph-medal-duotone" class="h-4 w-4 text-primary pointer-events-none" />
+              Nuxt DevTools <UIcon loading="lazy" name="i-ph-medal-duotone" class="h-4 w-4 text-primary pointer-events-none" />
             </template>
           </UPageCard>
           <UPageCard to="https://ui.nuxt.com/?utm_source=nuxt_website&utm_medium=modules" target="_blank" description="Fully styled and customizable components.">
             <template #title>
-              Nuxt UI <UIcon name="i-ph-medal-duotone" class="h-4 w-4 text-primary pointer-events-none" />
+              Nuxt UI <UIcon loading="lazy" name="i-ph-medal-duotone" class="h-4 w-4 text-primary pointer-events-none" />
             </template>
           </UPageCard>
         </UPageGrid>
@@ -77,7 +100,7 @@ const { copy } = useCopyToClipboard()
 
     <UPage id="smooth" class="pt-20 -mt-20">
       <template #left>
-        <UAside>
+        <UAside id="module-categories">
           <UNavigationTree :links="[{ label: 'Categories', disabled: true, children: categories }]" />
 
           <template #bottom>
@@ -137,11 +160,13 @@ const { copy } = useCopyToClipboard()
             :key="index"
             :to="`/modules/${module.name}`"
             :title="module.name"
-            class="flex flex-col"
+            class="module-card flex flex-col"
             :ui="{ body: { base: 'flex-1' }, footer: { base: 'bg-gray-100/50 dark:bg-gray-800/50' } }"
           >
             <template #icon>
-              <UAvatar :src="moduleImage(module.icon)" :icon="moduleIcon(module.category)" :alt="module.name" size="lg" :ui="{ rounded: 'rounded-lg' }" />
+              <UAvatar
+                loading="lazy"
+                :src="moduleImage(module.icon)" :icon="moduleIcon(module.category)" :alt="module.name" size="lg" :ui="{ rounded: 'rounded-lg' }" />
             </template>
 
             <template #title>


### PR DESCRIPTION
# The Problem

The page has hight render time especially for recalculate styles layout also paint is not optimal.

![Browser Render Pipeline improvements nuxt](https://github.com/nuxt/nuxt.com/assets/10064416/76333dd2-4c75-4d97-b271-bd7dc812dd6f)

## Steps to reproduce

1. Visite https://nuxt.com/modules as it is a good candidate to quickly test it. 
2. As I'm on a _MacBook Pro M2 Max_ I used **4x throttling** to emulate more commonly used devices 
3. Hit the toggle dark mode button a couple of times in a row
<img width="1238" alt="Screenshot 2024-01-11 at 13 33 03" src="https://github.com/nuxt/nuxt.com/assets/10064416/d7fb2316-0a66-46ab-8a42-ce7bab9881b2">

You should see a heavy delay in responsive ness due to heavy recalc and layouting.

 ## Measurement
 
 **Desktop unthrottled**

<img width="1231" alt="Screenshot 2024-01-11 at 13 40 21" src="https://github.com/nuxt/nuxt.com/assets/10064416/0cf448a2-6618-49ed-a770-d5c1e0b0aba3">
 
 **Desktop 4x throttled**

<img width="1231" alt="Screenshot 2024-01-11 at 13 40 04" src="https://github.com/nuxt/nuxt.com/assets/10064416/c585d74c-fc75-4f86-b534-b8a178409555">


 **Mobile unthrottled**

<img width="1231" alt="Screenshot 2024-01-11 at 13 41 45" src="https://github.com/nuxt/nuxt.com/assets/10064416/9ce25ecf-8e55-42d5-a93d-5af7ce7ba9c2">
 
**Mobile 4x throttled**
<img width="1231" alt="Screenshot 2024-01-11 at 13 41 30" src="https://github.com/nuxt/nuxt.com/assets/10064416/6e38fb31-a9dd-4fe6-a308-09c2937025df">


 # Solution 

Use CSS techniques that improve rendering

- [contain](https://caniuse.com/css-containment)
- [content-visibility](https://caniuse.com/?search=content-visibility)

# Poc

To get quick insight how the changes improve rendering I used source overwrites in the Chrome DevTools.

Here the used snippet:

```css
/* Contain and content visibility */
img, svg, span[class^="i-ph"] {
 contain:content;
}

header > div {
 contain:size;

}


#smooth > div:nth-child(2) div.grid > div,
footer h3, footer li,
span[class^="i-ph"] {
    content-visibility: auto;
}


#smooth > div:nth-child(2) div.grid > div {
    intrinsic-sice: 238px;
}

footer h3, footer li {
    intrinsic-sice: 18px;
}
span[class^="i-ph"] {
 intrinsic-sice: 20px;
}

/* Mobile/Tablet */
#smooth > div:first-child {
  display: none;
}

```

# This PR includes

style adoptions as well as adding img lazy loading in the following files:
- index
- components:
  - AppFooter
  - AppHeader
- blog
  - slug
  - index
- enterprise 
  - job
  - sponsors
- modules
  - slug
  - index

## Measurement before/after 4x throttled

**Mini map comparison**
<img width="573" alt="Screenshot 2024-01-11 at 14 00 09" src="https://github.com/nuxt/nuxt.com/assets/10064416/791d4b29-843f-452a-b8b7-3d75a3d9b080">

**Mini map comparison inc CWV plugin**
<img width="1231" alt="Screenshot 2024-01-11 at 13 59 56" src="https://github.com/nuxt/nuxt.com/assets/10064416/257a96f6-75dd-4f6f-ab9d-0343d63da5e5">


--- 

Im happy to adjust/move code around as I am not really familiar with the code base and assume the location of the code could be improved... 

All theory on the improvements can be found here: https://github.com/push-based/css-contain-and-content-visibility-research 

