### PR TITLE
docs(github-pages.md): Fix deployment example

### DIFF
--- a/content/3.deploy/github-pages.md
+++ b/content/3.deploy/github-pages.md
@@ -40,9 +40,7 @@ jobs:
           node-version: "20"
       # Pick your own package manager and build script
       - run: npm install
-      - run: npm run build
-          env:
-            NITRO_PRESET: github_pages
+      - run: npx nuxt build --preset github_pages
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/content/3.deploy/github-pages.md
+++ b/content/3.deploy/github-pages.md
@@ -40,7 +40,9 @@ jobs:
           node-version: "20"
       # Pick your own package manager and build script
       - run: npm install
-      - run: npm run build --preset=github_pages
+      - run: npm run build
+          env:
+            NITRO_PRESET: github_pages
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
# The Problem

The previous version of github-pages.md had a deployment example that would generate a Nuxt server, instead of a static site.

## How does this fix the issue?
To fix this I simply explicitly defined the environment variable that [the Nitro Github Pages Deployment template](https://nitro.unjs.io/deploy/providers/github-pages) showcased.

This fixes the issue of the workflow file generating a Nuxt server instead of a static site.