### PR TITLE
docs: provide guidance on overwriting azure swa defaults

### DIFF
--- a/content/3.deploy/azure.md
+++ b/content/3.deploy/azure.md
@@ -44,7 +44,23 @@ It adds the following properties based on the following criteria:
 
 ### Custom Configuration
 
-You can alter the generated configuration using `azure.config` option.
+You can alter the generated configuration using `azure.config` option. For instance, if you wanted to specify a Node runtime for your Azure Functions, edit your `nuxt.config.ts` file to the following:
+
+```
+export default defineNuxtConfig({
+  [...]
+  nitro: {
+    azure: {
+      config: {
+        [...]
+        platform: {
+          apiRuntime: "node:18"
+        }
+      }
+    }
+  }
+})
+```
 
 Custom routes will be added and matched first. In the case of a conflict (determined if an object has the same route property), custom routes will override generated ones.
 

--- a/content/3.deploy/azure.md
+++ b/content/3.deploy/azure.md
@@ -46,15 +46,15 @@ It adds the following properties based on the following criteria:
 
 You can alter the generated configuration using `azure.config` option. For instance, if you wanted to specify a Node runtime for your Azure Functions, edit your `nuxt.config.ts` file to the following:
 
-```
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
-  [...]
+  // ...
   nitro: {
     azure: {
       config: {
-        [...]
+        // ...
         platform: {
-          apiRuntime: "node:18"
+          apiRuntime: 'node:18'
         }
       }
     }


### PR DESCRIPTION
It was brought up that Nuxt overwrites the apiRuntime specified in the staticwebapp.config.json file. There is some documentation indicating that this can be overwritten, but without a good knowledge of how Nitro options are loaded, some folks are reporting lacking some guidance.

I recommend adding a snippet of the nuxt.config.ts file that will enable custom overrides for custom configuration.