### PR TITLE
feat: preview button for examples

### DIFF
--- a/pages/docs/[...slug].vue
+++ b/pages/docs/[...slug].vue
@@ -114,6 +114,17 @@ defineOgImage({
     <UPageHeader v-bind="page">
       <template #headline>
         <UBreadcrumb :links="breadcrumb" />
+        <UTooltip v-if="page._path.includes('/docs/examples/')" class="absolute right-4" text="Preview">
+          <UButton
+            :to="`https://${page._path.replace('/docs/examples/', '').split('/').pop()}.example.nuxt.space`"
+            icon="i-ph-arrow-up-right"
+            color="gray"
+            :ui="{ rounded: 'rounded-full' }"
+            external
+            target="_blank"
+            size="lg"
+          />
+        </UTooltip>
       </template>
     </UPageHeader>
 


### PR DESCRIPTION
this PR will add a button to examples domain link, in case user wants to see a preview and use it right away until stackblitz install and build...

> note: I'm aware that this might not be the best way to handle the link, we can add the links through `MD` if you think having this button is a good idea


https://github.com/nuxt/nuxt.com/assets/38922203/7e0436eb-2315-47de-bf89-5dc4c03821ed

