### PR TITLE
fix: add links to 'Zero-Config providers' on Nitro page

### DIFF
--- a/content/3.deploy/aws-amplify.md
+++ b/content/3.deploy/aws-amplify.md
@@ -12,7 +12,7 @@ website: 'https://aws.amazon.com/amplify/?trk=bed847b4-6e9f-4e09-ba09-0d4680a044
 ::tip
 **Zero Configuration ✨**
 :br
-Integration with AWS Amplify is possible with zero configuration.
+Integration with AWS Amplify is possible with zero configuration, [learn more](https://nitro.unjs.io/deploy#zero-config-providers).
 ::
 
 ## Setup

--- a/content/3.deploy/azure.md
+++ b/content/3.deploy/azure.md
@@ -12,7 +12,7 @@ website: 'https://azure.microsoft.com/en-us/services/app-service/static/'
 ::tip
 **Zero Configuration ✨**
 :br
-Integration with Azure Static Web Apps provider is possible with zero configuration.
+Integration with Azure Static Web Apps provider is possible with zero configuration, [learn more](https://nitro.unjs.io/deploy#zero-config-providers).
 ::
 
 Azure Static Web Apps are designed to be deployed continuously in a [GitHub Actions workflow](https://docs.microsoft.com/en-us/azure/static-web-apps/github-actions-workflow). By default, Nuxt will detect this deployment environment to enable the `azure` preset.

--- a/content/3.deploy/cleavr.md
+++ b/content/3.deploy/cleavr.md
@@ -10,7 +10,7 @@ website: 'https://cleavr.io/'
 ::tip
 **Zero Configuration ✨**
 :br
-Integration with this provider is possible with zero configuration.
+Integration with this provider is possible with zero configuration, [learn more](https://nitro.unjs.io/deploy#zero-config-providers).
 ::
 
 ## Setup

--- a/content/3.deploy/cloudflare.md
+++ b/content/3.deploy/cloudflare.md
@@ -12,7 +12,7 @@ website: 'https://pages.cloudflare.com/'
 ::tip
 **Zero Configuration ✨**
 :br
-Integration with Cloudflare Pages is possible with zero configuration, [learn more](https://nitro.unjs.io/deploy/#zero-config-providers).
+Integration with Cloudflare Pages is possible with zero configuration, [learn more](https://nitro.unjs.io/deploy#zero-config-providers).
 ::
 
 ### Git Integration

--- a/content/3.deploy/netlify.md
+++ b/content/3.deploy/netlify.md
@@ -12,7 +12,7 @@ website: https://www.netlify.com/
 ::tip
 **Zero Configuration ✨**
 :br
-Integration with Netlify is possible with zero configuration.
+Integration with Netlify is possible with zero configuration, [learn more](https://nitro.unjs.io/deploy#zero-config-providers).
 ::
 
 ## Setup

--- a/content/3.deploy/stormkit.md
+++ b/content/3.deploy/stormkit.md
@@ -10,7 +10,7 @@ website: 'https://www.stormkit.io/'
 ::tip
 **Zero Configuration ✨**
 :br
-Integration with [Stormkit](https://www.stormkit.io/) is possible with zero configuration.
+Integration with [Stormkit](https://www.stormkit.io/) is possible with zero configuration, [learn more](https://nitro.unjs.io/deploy#zero-config-providers).
 ::
 
 ## Setup

--- a/content/3.deploy/vercel.md
+++ b/content/3.deploy/vercel.md
@@ -12,7 +12,7 @@ website: 'https://vercel.com/'
 ::tip
 **Zero Configuration ✨**
 :br
-Integration with Vercel is possible with zero configuration.
+Integration with Vercel is possible with zero configuration, [learn more](https://nitro.unjs.io/deploy#zero-config-providers).
 ::
 
 ## Deploy using Git


### PR DESCRIPTION
### 🔗 Linked issue

closed #1520 .

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- [x] Cloudflare page link has been corrected to the correct one.
- [x] Added **learn more** to the providers listed under "Zero-Config Providers" on [Nitro's page](https://nitro.unjs.io/deploy#zero-config-providers)


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.