### PR TITLE
Fix typos and improve grammar on enterprise support page

### DIFF
--- a/content/8.enterprise/1.support.yml
+++ b/content/8.enterprise/1.support.yml
@@ -25,7 +25,7 @@ call:
   description: >-
     ## Talk to us
 
-    Book 30 minutes with us to learn more about our support solutions, present your needs and your project and get personnalized proposions to solve your issues.
+    Book 30 minutes with us to learn more about our support solutions, present your needs and your project, and get personalized proposals to solve your issues.
   button:
     icon: i-ph-calendar-plus-duotone
     label: 'Choose a meeting'


### PR DESCRIPTION
This PR fixes a couple typos and improves grammar on the enterprise support page.