### PR TITLE
fix: edit this article link

### DIFF
--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -63,7 +63,7 @@ const links = [
   {
     icon: 'i-ph-pen-duotone',
     label: 'Edit this article',
-    to: `https://github.com/nuxt/nuxt.com/edit/main/content/7.blog/${article.value._file}`,
+    to: `https://github.com/nuxt/nuxt.com/edit/main/content/${article.value._file}`,
     target: '_blank'
   }, {
     icon: 'i-ph-shooting-star-duotone',


### PR DESCRIPTION
I believe this will fix the issue of the current "Edit this article" links/buttons where the links have an extra `7.blog/` in them.

![image](https://github.com/nuxt/nuxt.com/assets/47499684/19d1d63d-8a47-4ec7-9bbc-63adbf7ce762)
