### PR TITLE
fix: HomeSectionContributors avatar grid

### DIFF
--- a/components/home/HomeSectionContributors.vue
+++ b/components/home/HomeSectionContributors.vue
@@ -79,20 +79,23 @@ async function nextContributors() {
           :key="username"
           :href="`https://nuxters.nuxt.com/${username}`"
           target="_blank"
-          class="absolute inset-0 block transition-all"
+          class="absolute inset-0 flex transition-all"
+          height="80px"
+          width="80px"
           :style="{
             'transition-delay': `${(index % 8 + Math.floor(index / 8)) * 20}ms`
           }"
         >
-          <UTooltip :text="username">
-            <img
-              :src="`https://ipx.nuxt.com/f_auto,s_80x80/gh_avatar/${username}`"
-              :srcset="`https://ipx.nuxt.com/f_auto,s_160x160/gh_avatar/${username} 2x`"
+          <UTooltip :text="username" class="w-full">
+            <NuxtImg
+              :src="`/gh_avatar/${username}`"
+              provider="ipx"
+              densities="x1 x2"
               :alt="username"
               loading="lazy"
               :title="username"
               class="rounded-xl w-full h-full transition lg:hover:scale-125"
-            >
+            />
           </UTooltip>
         </a>
       </Transition>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -146,6 +146,11 @@ export default defineNuxtConfig({
   ui: {
     icons: ['simple-icons', 'ph', 'uil', 'heroicons', 'octicon', 'logos']
   },
+  image: {
+    ipx: {
+      baseURL: 'https://ipx.nuxt.com'
+    }
+  },
   content: {
     navigation: {
       fields: ['titleTemplate']


### PR DESCRIPTION
Currently avatars not use full space of the grid

Before:
![Capture d’écran 2024-04-14 à 20 08 27](https://github.com/nuxt/nuxt.com/assets/1840026/7c989f08-32c9-4eb1-81ae-f73c76ca6da1)


After:
![Capture d’écran 2024-04-14 à 20 04 59](https://github.com/nuxt/nuxt.com/assets/1840026/0ef43575-145e-4e1b-8150-50ba622ac161)

I also used nuxt image to generate image links, like we did on Nuxters : https://github.com/nuxt/nuxters/blob/main/components/home/HomeContributors.vue
