### PR TITLE
fix: specify only one font so that @nuxt/fonts detects it

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,7 +33,7 @@ export default <Partial<Config>>{
         }
       },
       fontFamily: {
-        sans: ['Inter var experimental', 'Inter var', 'Inter', ...defaultTheme.fontFamily.sans]
+        sans: ['Inter', ...defaultTheme.fontFamily.sans]
       },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))'


### PR DESCRIPTION
Current CSS output:
![image](https://github.com/nuxt/nuxt.com/assets/33054273/05d03dc4-ed5c-4054-a191-81d286cf392c)

Fixed CSS output:
![image](https://github.com/nuxt/nuxt.com/assets/33054273/bb4208c5-a0de-4b10-a06b-5f3345c9d315)
