### PR TITLE
docs: refactor npm caching for gitlab pages template

### DIFF
--- a/content/3.deploy/gitlab.md
+++ b/content/3.deploy/gitlab.md
@@ -15,7 +15,7 @@ GitLab Pages only support static sites, Nuxt will pre-render your application to
 ::caution
 If you are **not** using a custom domain, you need to set `NUXT_APP_BASE_URL` to your repository-slug for your build step.
 
-**Example**: `https://<group/user>.gitlab.io/<repository>/`: `NUXT_APP_BASE_URL=/<repository>/ npx nuxt build --preset github_pages`
+**Example**: `https://<group/user>.gitlab.io/<repository>/`: `NUXT_APP_BASE_URL=/<repository>/ npm run genertate`
 ::
 
 ## Deployment

--- a/content/3.deploy/gitlab.md
+++ b/content/3.deploy/gitlab.md
@@ -12,24 +12,31 @@ Nuxt supports deploying on the [GitLab Pages](https://docs.gitlab.com/ee/user/pr
 GitLab Pages only support static sites, Nuxt will pre-render your application to static HTML files.
 ::
 
+::caution
+If you are **not** using a custom domain, you need to set `NUXT_APP_BASE_URL` to your repository-slug for your build step.
+
+**Example**: `https://<group/user>.gitlab.io/<repository>/`: `NUXT_APP_BASE_URL=/<repository>/ npx nuxt build --preset github_pages`
+::
+
 ## Deployment
 
 1. Here is an example GitLab Pages workflow to deploy your site to GitLab Pages:
 
 ```yaml [.gitlab-ci.yml]
-# The Docker image that will be used to build your app
-image: node:lts
-# Functions that should be executed before the build script is run
-before_script:
-   - npm install
-cache:
-   paths:
-      # Directories that are cached between builds
-      - node_modules/
+# Job name has to be `pages`. See https://docs.gitlab.com/ee/user/project/pages/#how-it-works
 pages:
+   image: node
+   before_script:
+      - npm ci --cache .npm --prefer-offline
    script:
       # Specify the steps involved to build your app here
       - npm run generate
+   cache: # https://docs.gitlab.com/ee/ci/caching/#cache-nodejs-dependencies
+      key:
+         files:
+         - package-lock.json
+      paths:
+         - .npm/
    artifacts:
       paths:
          # The directory that contains the built files to be published


### PR DESCRIPTION
related to https://github.com/nuxt/nuxt.com/pull/1548#discussion_r1609858855


removes global defaults.

cache npm deps via cache not node_modules https://docs.gitlab.com/ee/ci/caching/#cache-nodejs-dependencies