### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Copy the output of the command above and paste it in the `NUXT_DOCS_PATH` variab
 Start the development server:
 
 ```bash
-npm run dev
+pnpm dev
 ```
 
 ### Add a Nuxt Template
@@ -61,7 +61,7 @@ Note that this is not required to run in development and contribute to the Nuxt 
 Build the application for production:
 
 ```bash
-npm run generate
+pnpm generate
 ```
 
 ## License


### PR DESCRIPTION
Provide `pnpm` instead of `npm` since the deps are installed by `pnpm` and we have `pnpm-lock.yaml`.