### PR TITLE
chore(vscode): remove `eslint.experimental.useFlatConfig`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "eslint.experimental.useFlatConfig": true
-}


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`eslint.experimental.useFlatConfig` has been deprecated in vscode-eslint v3.0.5.
Flat Config is enabled by default in ESLint v9.
So I removed the option.

- ref1: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
- ref2: https://eslint.org/docs/latest/use/configure/migration-guide#visual-studio-code-support