### PR TITLE
feat(modules): added latest version of module to module page

### DIFF
--- a/pages/modules/[slug].vue
+++ b/pages/modules/[slug].vue
@@ -123,6 +123,14 @@ defineOgImageComponent('Docs', {
           </NuxtLink>
         </UTooltip>
 
+        <span class="hidden lg:block text-gray-500 dark:text-gray-400">&bull;</span>
+
+        <UTooltip text="GitHub Stars">
+          <NuxtLink class="flex items-center gap-1.5" :to="`https://github.com/${module.repo}`" target="_blank">
+            <span class="text-sm font-medium">v{{module.stats.version}}</span> 
+          </NuxtLink>
+        </UTooltip>
+
         <div class="mx-3 h-6 border-l border-gray-200 dark:border-gray-800 w-px hidden lg:block" />
 
         <div v-for="(maintainer, index) in module.maintainers" :key="maintainer.github" class="flex items-center gap-3">

--- a/types/modules.ts
+++ b/types/modules.ts
@@ -21,6 +21,7 @@ export interface Module {
   // tags: string[]
   compatibility: { nuxt: string, requires: { bridge: boolean } }
   stats: {
+    version: any
     downloads: number
     stars: number
     publishedAt: number


### PR DESCRIPTION
Added the module version to the module page from `module.stats.version` and added missing declaration to stats.

![image](https://github.com/user-attachments/assets/858f3ad3-fe65-44cc-b77c-ce45808628d6)
