### PR TITLE
docs: update GitHub Pages deployment workflow example

### DIFF
--- a/content/3.deploy/github-pages.md
+++ b/content/3.deploy/github-pages.md
@@ -48,7 +48,7 @@ jobs:
       - run: npm install
       - run: npx nuxt build --preset github_pages
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./.output/public
   # Deployment job
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
 ```
 
 ::read-more{to="https://nitro.unjs.io/deploy/providers/github-pages" target="_blank"}


### PR DESCRIPTION
I updated the example workflow to deploy on GitHub Pages by upgrading `actions/upload-pages-artifact` from v1 to v3 and `actions/deploy-pages` from v1 to v4.

This worked fine for me, especially for Bun's package manager 🚀 