### PR TITLE
chore: fix normalize paths on Windows in dev server

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,8 +7,7 @@ function normalizedDirPath(path?: string) {
     return path
   }
 
-  const windowsPath = path.replace(/\\/g, '/')
-  return windowsPath.startsWith('file:///') ? windowsPath : `file:///${windowsPath}`
+  return path.replace(/\\/g, '/')
 }
 
 const docsSourceBase = normalizedDirPath(process.env.NUXT_DOCS_PATH)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
NA

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
This PR fixes internal changes in Nuxt handling Windows paths normalization in dev server, just removes the `file:///` prefix in the Nuxt config file (continuation of https://github.com/nuxt/nuxt.com/pull/1422)

![imagen](https://github.com/user-attachments/assets/08ec517e-3f5a-45d8-ba34-53729cdd12b0)
_Error using `file:///` prefix_

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
