### PR TITLE
docs: info about env vars with firebase hosting

### DIFF
--- a/content/3.deploy/firebase.md
+++ b/content/3.deploy/firebase.md
@@ -154,3 +154,19 @@ When using Firebase Hosting together with Cloud Functions or Cloud Run, cookies 
 ::read-more{to="https://firebase.google.com/docs/hosting/manage-cache#using_cookies" target="\_blank"}
 For more information, refer to the **Firebase documentation**.
 ::
+
+## Working with Environment Variables
+
+To set environment variables for your Firebase functions, you need to copy the `.env` file to the `.output/server` directory.
+You can do this by adding a `postbuild` script to your `package.json`, that will automatically run after the build command:
+
+```json [package.json]
+{
+  "scripts": {
+    "postbuild": "cp .env .output/server/.env"
+  }
+}
+
+::read-more{to="https://firebase.google.com/docs/functions/config-env?gen=2nd#env-variables" target="\_blank"}
+For more information, refer to the **Firebase documentation**.
+::

--- a/content/3.deploy/firebase.md
+++ b/content/3.deploy/firebase.md
@@ -166,6 +166,7 @@ You can do this by adding a `postbuild` script to your `package.json`, that will
     "postbuild": "cp .env .output/server/.env"
   }
 }
+```
 
 ::read-more{to="https://firebase.google.com/docs/functions/config-env?gen=2nd#env-variables" target="\_blank"}
 For more information, refer to the **Firebase documentation**.


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

I think this is a small issue but the solution is not intuitive, since unlike other provides like `netlify`, there is no panel for registring env variables on firebase function (afaik). I noticed this was already reported in https://github.com/nuxt/nuxt/issues/19988

Another solution would be to include this information in the Nitro documentation, since it's more specific about Nitro, and there is already a link to it in this page

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
