### PR TITLE
fix: fixed broken Community Edit This Page link

### DIFF
--- a/pages/docs/[...slug].vue
+++ b/pages/docs/[...slug].vue
@@ -48,7 +48,7 @@ const titleTemplate = computed(() => {
 const communityLinks = computed(() => [{
   icon: 'i-ph-pen',
   label: 'Edit this page',
-  to: `https://github.com/nuxt/nuxt/edit/main/docs/${page?.value?._file?.split('/').slice(1).join('/')}`,
+  to: `https://github.com/nuxt/nuxt/blob/main/docs/${page?.value?._file?.split('/').slice(1).join('/')}`,
   target: '_blank'
 }, {
   icon: 'i-ph-chat-centered-text',


### PR DESCRIPTION
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
![image](https://github.com/user-attachments/assets/f1327fe8-ae8d-43f7-b16c-3ecb03f9fc53)

#### What was wrong?
The **Edit this page** link was broken and linked to a Github 404 page (ex [https://github.com/nuxt/nuxt/edit/main/docs/1.getting-started/4.styling.md](https://github.com/nuxt/nuxt/edit/main/docs/1.getting-started/4.styling.md)). This link also assumed you could edit the files directly and not through a fork.

#### What was the change/fix?
The **Edit this page** now links to the [/blob/](https://github.com/nuxt/nuxt/blob/main/docs/1.getting-started/1.introduction.md) (ex: https://github.com/nuxt/nuxt/blob/main/docs/1.getting-started/1.introduction.md) instead of the [/edit/](https://github.com/nuxt/nuxt/edit/main/docs/1.getting-started/1.introduction.md) and leaves it up to the user to fork and then edit.
