### PR TITLE
fix: feature card background overlapping rounded corners on hover in dark mode

### DIFF
--- a/components/home/HomeSectionFeatures.vue
+++ b/components/home/HomeSectionFeatures.vue
@@ -16,6 +16,7 @@ defineProps<{
       :key="index"
       v-bind="feature"
       :ui="{
+        base: 'overflow-hidden',
         background: 'dark:bg-gradient-to-b from-gray-700/50 to-gray-900/50',
         body: {
           base: 'flex-1',


### PR DESCRIPTION
### 🔗 Linked issue

NA

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

In dark mode, hovering over a feature card makes its background overlap the card's rounded corners:

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/04423dbf-0cd1-43ce-9661-12c3477d9d68">

This is caused by setting a background color on the card's content in dark mode:

https://github.com/nuxt/nuxt.com/blob/8a3a95b4cc6b5e09149325a65249a5594328f7a6/components/home/HomeSectionFeatures.vue#L22

At first I thought maybe it'd be best to address this in Nuxt UI, but Nuxt UI deliberately _does not_ set `overflow-hidden` on the Card component that UPageCard extends: https://github.com/nuxt/ui/issues/806#issuecomment-1878964137. So I've added `overflow-hidden` to the `ui` object here which contains the buggy style.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
