### PR TITLE
docs: Add pnpm version requirement notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ Welcome to the Nuxt website repository available on [nuxt.com](https://nuxt.com)
 
 ## Setup
 
-Ensure your pnpm version matches the one specified in the `packageManager` field in `package.json`.
-
-Install all dependencies
+Make sure to enable corepack and install the dependencies:
 
 ```bash
+corepack enable
 pnpm install
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Welcome to the Nuxt website repository available on [nuxt.com](https://nuxt.com)
 
 ## Setup
 
-Make sure to install the dependencies
+Ensure your pnpm version matches the one specified in the `packageManager` field in `package.json`.
+
+Install all dependencies
 
 ```bash
 pnpm install


### PR DESCRIPTION
### 🔗 Linked issue

I've found no open issue about it

### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I attempted to run the documentation locally using `pnpm` 9.6.0 and followed all the basic instructions, but the page kept loading indefinitely. Before opening an issue, I noticed that my `pnpm` version didn't match the one specified in `packageManager` in `package.json`.

To prevent similar issues for others running the project locally, I've added a note in the README to clarify the importance of using the correct `pnpm` version. This should help avoid potential confusion and problems.
