### PR TITLE
Cloudflare Auto Minify deprecated

### DIFF
--- a/content/3.deploy/cloudflare.md
+++ b/content/3.deploy/cloudflare.md
@@ -65,12 +65,6 @@ In this case, you will have to set the preset manually.
     wrangler pages deploy dist/
     ```
 
-## Disable Auto Minify
-
-Make sure to disable the minification of HTML, CSS and JavaScript in **CloudFlare -> Speed -> Optimization -> Auto Minify** to avoid any Vue hydration.
-
-![Disable Cloudflare auto minify](/assets/deploy/cloudflare-auto-minify.png)
-
 ## Learn more
 
 ::read-more{to="https://nitro.unjs.io/deploy/providers/cloudflare" target="_blank"}


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/nuxt/pull/29812

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Cloudflare's Auto Minify feature has been deprecated. Therefore, it is no longer available in the Cloudflare dashboard interface. Updating the document should clear up the confusion.
https://community.cloudflare.com/t/deprecating-auto-minify/655677