### PR TITLE
docs: clarify `shared/` is v4 only

### DIFF
--- a/content/7.blog/27.v3-14.md
+++ b/content/7.blog/27.v3-14.md
@@ -22,7 +22,7 @@ Loading the nuxt config file, as well as modules and other build-time code, is n
 
 You should never import Vue app code in your nitro code (or the other way around). But this has meant a friction point when it comes to sharing types or utilities that _don't_ rely on the nitro/vue contexts.
 
-For this, we have a new `shared/` folder ([#28682](https://github.com/nuxt/nuxt/pull/28682)). You can try it by [testing Nuxt 4](/docs/getting-started/upgrade#testing-nuxt-4). You can't import Vue or nitro code _into_ files in this folder, but it produces auto-imports you can consume throughout the rest of your app.
+For this, we have a new `shared/` folder ([#28682](https://github.com/nuxt/nuxt/pull/28682)). You can't import Vue or nitro code _into_ files in this folder, but it produces auto-imports (if you're using `compatibilityVersion: 4`) which you can consume throughout the rest of your app.
 
 If needed you can use the new `#shared` alias which points to this folder.
 

--- a/content/7.blog/27.v3-14.md
+++ b/content/7.blog/27.v3-14.md
@@ -22,11 +22,11 @@ Loading the nuxt config file, as well as modules and other build-time code, is n
 
 You should never import Vue app code in your nitro code (or the other way around). But this has meant a friction point when it comes to sharing types or utilities that _don't_ rely on the nitro/vue contexts.
 
-For this, we have a new `shared/` folder ([#28682](https://github.com/nuxt/nuxt/pull/28682)). You can't import Vue or nitro code _into_ files in this folder, but it produces auto-imports you can consume throughout the rest of your app.
+For this, we have a new `shared/` folder ([#28682](https://github.com/nuxt/nuxt/pull/28682)) which you can enable with the `compatibilityVersion: 4` flag. You can't import Vue or nitro code _into_ files in this folder, but it produces auto-imports you can consume throughout the rest of your app.
 
 If needed you can use the new `#shared` alias which points to this folder.
 
-The shared folder is alongside your `server/` folder. (If you're using `compatibilityVersion: 4`, this means it's not inside your `app/` folder.)
+The shared folder is alongside your `server/` folder.
 
 ### 🦀 `rspack` builder
 

--- a/content/7.blog/27.v3-14.md
+++ b/content/7.blog/27.v3-14.md
@@ -26,7 +26,7 @@ For this, we have a new `shared/` folder ([#28682](https://github.com/nuxt/nuxt/
 
 If needed you can use the new `#shared` alias which points to this folder.
 
-The shared folder is alongside your `server/` folder.
+The shared folder is alongside your `server/` folder. (If you're using `compatibilityVersion: 4`, this means it's not inside your `app/` folder.)
 
 ### 🦀 `rspack` builder
 

--- a/content/7.blog/27.v3-14.md
+++ b/content/7.blog/27.v3-14.md
@@ -46,7 +46,7 @@ We now have a new `addServerTemplate` utility ([#29320](https://github.com/nuxt/
 
 ### 🚧 v4 changes
 
-We've merged some changes which only take effect with `compatibilityVersion: 4`, but which you can opt-into earlier.
+We've merged some changes which only take effect with `compatibilityVersion: 4`, but which [you can opt-into earlier](/docs/getting-started/upgrade#testing-nuxt-4).
 
 1. previously, if you had a component like `~/components/App/Header.vue` this would be visible in your devtools as `<Header>`. From v4 we ensure this is `<AppHeader>`, but it's opt-in to avoid breaking any manual `<KeepAlive>` you might have implemented. ([#28745](https://github.com/nuxt/nuxt/pull/28745)).
 2. Nuxt scans page metadata from your files, before calling `pages:extend`. But this has led to some confusing behaviour, as pages added at this point do not end up having their page metadata respected. So we now do not scan metadata before calling `pages:extend`. Instead, we have a new `pages:resolved` hook, which is called after `pages:extend`, after all pages have been augmented with their metadata. I'd recommend opting into this by setting `experimental.scanPageMeta` to `after-resolve`, as it solves a number of bugs.

--- a/content/7.blog/27.v3-14.md
+++ b/content/7.blog/27.v3-14.md
@@ -22,7 +22,7 @@ Loading the nuxt config file, as well as modules and other build-time code, is n
 
 You should never import Vue app code in your nitro code (or the other way around). But this has meant a friction point when it comes to sharing types or utilities that _don't_ rely on the nitro/vue contexts.
 
-For this, we have a new `shared/` folder ([#28682](https://github.com/nuxt/nuxt/pull/28682)) which you can enable with the `compatibilityVersion: 4` flag. You can't import Vue or nitro code _into_ files in this folder, but it produces auto-imports you can consume throughout the rest of your app.
+For this, we have a new `shared/` folder ([#28682](https://github.com/nuxt/nuxt/pull/28682)). You can try it by [testing Nuxt 4](/docs/getting-started/upgrade#testing-nuxt-4). You can't import Vue or nitro code _into_ files in this folder, but it produces auto-imports you can consume throughout the rest of your app.
 
 If needed you can use the new `#shared` alias which points to this folder.
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#29960

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `server/` folder is a v4 feature only (see @manniL's [comment in the linked issue](https://github.com/nuxt/nuxt/issues/29960#issuecomment-2486793071)).

This PR clarifies that `compatibilityVersion: 4` needs to be enabled. It also clarifies that this is only available in v4 by removing a reference to "if you enable v4…".

I'm happy to tweak the wording, if it can be improved!