### PR TITLE
chore: Differentiate between UInputCopy label & value

### DIFF
--- a/app/components/UInputCopy.vue
+++ b/app/components/UInputCopy.vue
@@ -4,6 +4,10 @@ defineProps({
     type: String,
     required: true
   },
+  label: {
+    type: String,
+    required: false
+  },
   size: {
     type: String as () => 'lg',
     default: 'lg'
@@ -14,7 +18,7 @@ const { copy, copied } = useClipboard()
 
 <template>
   <label>
-    <UInput :model-value="value" :size="size" disabled :ui="{ icon: { trailing: { pointer: '' } } }" icon="i-ph-terminal">
+    <UInput :model-value="label ? label : value" :size="size" disabled :ui="{ icon: { trailing: { pointer: '' } } }" icon="i-ph-terminal">
       <div class="absolute inset-0" :class="[copied ? 'cursor-default' : 'cursor-copy']" @click="copy(value)" />
       <template #trailing>
         <UButton

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -80,7 +80,7 @@ useSeoMeta({
               Nuxt in 100 Seconds
             </UButton>
           </div>
-          <UInputCopy value="npx nuxi@latest init <my-app>" class="w-full" />
+          <UInputCopy value="npx nuxi@latest init " label="npx nuxi@latest init <my-app>" class="w-full" />
         </div>
 
         <UModal v-model="videoModalOpen" :ui="{ width: 'sm:max-w-4xl lg:max-w-5xl aspect-[16/9]' }">


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The button on the homepage allows you to copy the command to create a new nuxt project, currently the copied value includes the `<my-app>` bit at the end, which always has to be removed & replaced by the user.

This PR allows the `UInputCopy` to set both a `value` & `label`, using the latter as the display value only when present.

There are no visual changes from this PR, but the value on the clipboard will change from `npx nuxi@latest init <my-app>` to just `npx nuxi@latest init ` (including trailing space so the user can immediately type their project name)
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
