### PR TITLE
docs: fixing install command on home page

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -80,7 +80,7 @@ useSeoMeta({
               Nuxt in 100 Seconds
             </UButton>
           </div>
-          <UInputCopy value="npm create@latest nuxt" label="npm create@latest nuxt" class="w-full" />
+          <UInputCopy value="npm create nuxt@latest" label="npm create nuxt@latest" class="w-full" />
         </div>
 
         <UModal v-model="videoModalOpen" :ui="{ width: 'sm:max-w-4xl lg:max-w-5xl aspect-[16/9]' }">


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The install command on the nuxt.com home page is currently incorrect. It looks like a change a couple of days ago moved it away from a different command and introduced a typo. This tiny change just fixes the command.

