### PR TITLE
docs: fix typo in example for useHead

### DIFF
--- a/content/7.blog/26.nuxt-scripts.md
+++ b/content/7.blog/26.nuxt-scripts.md
@@ -44,7 +44,7 @@ Let's walk through adding a third-party script to your Nuxt app using a fictiona
 We start by loading the script using `useHead`.
 
 ```ts
-useHead({ scripts: [{ src: '/tracker.js', defer: true }] })
+useHead({ script: [{ src: '/tracker.js', defer: true }] })
 ```
 
 However, let's now try to get the script functionality working in our app.


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Updated the code example in the blog to correct the `useHead` example by changing `scripts` to `script`.
