### PR TITLE
chore: remove github silent option for vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,4 @@
 {
-  "github": {
-    "silent": true
-  },
   "redirects": [
     {
       "source": "/docs/",


### PR DESCRIPTION
github silent is now deprecated. (https://vercel.com/docs/project-configuration/git-configuration#github.silent)