### PR TITLE
perf: fetch modules list on client-side and use slimmer sponsors list

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -23,6 +23,9 @@ const { data: files } = useLazyAsyncData('search', () => {
   transform: data => data.flat()
 })
 
+const { fetchList } = useModules()
+onNuxtReady(() => fetchList())
+
 useHead({
   titleTemplate: title => title ? `${title} · Nuxt` : 'Nuxt: The Intuitive Web Framework',
   meta: [

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { footerLinks } = useNavigation()
+const { footerLinks } = useFooterLinks()
 </script>
 
 <template>

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -6,7 +6,7 @@ const logo = useTemplateRef('logo')
 const route = useRoute()
 const stats = useStats()
 const { copy } = useClipboard()
-const { headerLinks } = useNavigation()
+const { headerLinks } = useHeaderLinks()
 
 const version = computed(() => {
   const versionMatch = stats.value?.version?.match(/\d+\.\d+/)

--- a/app/composables/useNavigation.ts
+++ b/app/composables/useNavigation.ts
@@ -1,12 +1,8 @@
 import { createSharedComposable } from '@vueuse/core'
 
-const _useNavigation = () => {
-  const nuxtApp = useNuxtApp()
-  const searchTerm = ref<string>('')
-
+export const useHeaderLinks = createSharedComposable(() => {
+  const route = useRoute()
   const headerLinks = computed(() => {
-    const route = useRoute()
-
     return [{
       label: 'Docs',
       icon: 'i-lucide-book-marked',
@@ -138,48 +134,59 @@ const _useNavigation = () => {
       to: '/blog'
     }]
   })
+  return { headerLinks }
+})
 
-  const footerLinks = [{
-    label: 'Community',
-    children: [{
-      label: 'Nuxters',
-      to: 'https://nuxters.nuxt.com',
-      target: '_blank'
-    }, {
-      label: 'Team',
-      to: '/team'
-    }, {
-      label: 'Design Kit',
-      to: '/design-kit'
-    }]
+const footerLinks = [{
+  label: 'Community',
+  children: [{
+    label: 'Nuxters',
+    to: 'https://nuxters.nuxt.com',
+    target: '_blank'
   }, {
-    label: 'Products',
-    children: [{
-      label: 'Nuxt UI Pro',
-      to: 'https://ui.nuxt.com/pro?utm_source=nuxt-website&utm_medium=footer',
-      target: '_blank'
-    }, {
-      label: 'Nuxt Studio',
-      to: 'https://content.nuxt.com/studio/?utm_source=nuxt-website&utm_medium=footer',
-      target: '_blank'
-    }, {
-      label: 'NuxtHub',
-      to: 'https://hub.nuxt.com/?utm_source=nuxt-website&utm_medium=footer',
-      target: '_blank'
-    }]
+    label: 'Team',
+    to: '/team'
   }, {
-    label: 'Enterprise',
-    children: [{
-      label: 'Support',
-      to: '/enterprise/support'
-    }, {
-      label: 'Agencies',
-      to: '/enterprise/agencies'
-    }, {
-      label: 'Sponsors',
-      to: '/enterprise/sponsors'
-    }]
+    label: 'Design Kit',
+    to: '/design-kit'
   }]
+}, {
+  label: 'Products',
+  children: [{
+    label: 'Nuxt UI Pro',
+    to: 'https://ui.nuxt.com/pro?utm_source=nuxt-website&utm_medium=footer',
+    target: '_blank'
+  }, {
+    label: 'Nuxt Studio',
+    to: 'https://content.nuxt.com/studio/?utm_source=nuxt-website&utm_medium=footer',
+    target: '_blank'
+  }, {
+    label: 'NuxtHub',
+    to: 'https://hub.nuxt.com/?utm_source=nuxt-website&utm_medium=footer',
+    target: '_blank'
+  }]
+}, {
+  label: 'Enterprise',
+  children: [{
+    label: 'Support',
+    to: '/enterprise/support'
+  }, {
+    label: 'Agencies',
+    to: '/enterprise/agencies'
+  }, {
+    label: 'Sponsors',
+    to: '/enterprise/sponsors'
+  }]
+}]
+
+export const useFooterLinks = () => ({ footerLinks })
+
+const _useNavigation = () => {
+  const nuxtApp = useNuxtApp()
+  const searchTerm = ref<string>('')
+
+  const { headerLinks } = useHeaderLinks()
+  const { footerLinks } = useFooterLinks()
 
   const searchLinks = computed(() => [
     {
@@ -315,10 +322,12 @@ const _useNavigation = () => {
         }))
     }
 
-    Promise.all([
-      loadModules(),
-      loadHosting()
-    ]).catch(error => console.error('Error loading search results:', error))
+    onMounted(() => {
+      Promise.all([
+        loadModules(),
+        loadHosting()
+      ]).catch(error => console.error('Error loading search results:', error))
+    })
 
     return groups
   })

--- a/app/error.vue
+++ b/app/error.vue
@@ -10,23 +10,28 @@ defineProps<{ error: NuxtError }>()
 
 const { searchGroups, searchLinks, searchTerm } = useNavigation()
 
-const { data: navigation } = await useAsyncData('navigation', () => {
-  return Promise.all([
-    queryCollectionNavigation('docs'),
-    queryCollectionNavigation('blog')
-  ])
-}, {
-  transform: data => data.flat()
-})
-const { data: files } = useLazyAsyncData('search', () => {
-  return Promise.all([
-    queryCollectionSearchSections('docs'),
-    queryCollectionSearchSections('blog')
-  ])
-}, {
-  server: false,
-  transform: data => data.flat()
-})
+const [{ data: navigation }, { data: files }] = await Promise.all([
+  useAsyncData('navigation', () => {
+    return Promise.all([
+      queryCollectionNavigation('docs'),
+      queryCollectionNavigation('blog')
+    ])
+  }, {
+    transform: data => data.flat()
+  }),
+  useLazyAsyncData('search', () => {
+    return Promise.all([
+      queryCollectionSearchSections('docs'),
+      queryCollectionSearchSections('blog')
+    ])
+  }, {
+    server: false,
+    transform: data => data.flat()
+  })
+])
+
+const { fetchList } = useModules()
+onNuxtReady(() => fetchList())
 
 provide('navigation', navigation)
 </script>

--- a/app/pages/docs/[...slug].vue
+++ b/app/pages/docs/[...slug].vue
@@ -31,7 +31,7 @@ const asideNavigation = computed(() => {
   return navPageFromPath(path, navigation.value)?.children || []
 })
 
-const { headerLinks } = useNavigation()
+const { headerLinks } = useHeaderLinks()
 const links = computed(() => headerLinks.value.find(link => link.to === '/docs')?.children ?? [])
 
 const [{ data: page }, { data: surround }] = await Promise.all([

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -5,7 +5,7 @@ definePageMeta({
   heroBackground: '-z-10'
 })
 
-const [{ data: page }, { data: officialModules }, { data: sponsors }] = await Promise.all([
+const [{ data: page }, { data: officialModules }, { data: sponsorGroups }] = await Promise.all([
   useAsyncData('index', () => queryCollection('index').first()),
   useFetch<{ modules: Module[], stats: Stats }>('https://api.nuxt.com/modules', {
     key: 'official-modules',
@@ -548,40 +548,40 @@ onMounted(() => {
       }"
     >
       <div class="flex flex-col items-center">
-        <template v-for="({ tier, sponsors: value }) of sponsors" :key="tier">
+        <template v-for="({ tier, sponsors }) of sponsorGroups" :key="tier">
           <div class="w-full mb-24">
             <UBadge color="neutral" variant="subtle" class="capitalize mb-2">
-              {{ key }} sponsors
+              {{ tier }} sponsors
             </UBadge>
 
             <div class="w-full border border-(--ui-border) rounded-lg">
               <table class="w-full">
                 <tbody>
-                  <template v-for="(_, rowIndex) in Math.ceil(value.length / 3)" :key="rowIndex">
+                  <template v-for="(_, rowIndex) in Math.ceil(sponsors.length / 3)" :key="rowIndex">
                     <tr>
                       <template v-for="colIndex in 3" :key="colIndex">
                         <td
-                          v-if="(rowIndex * 3) + colIndex - 1 < value.length"
+                          v-if="(rowIndex * 3) + colIndex - 1 < sponsors.length"
                           class="border-b border-r border-(--ui-border) p-0 w-1/3 h-[120px]"
                           :class="{
                             'border-r-0': colIndex === 3,
-                            'border-b-0': rowIndex === Math.ceil(value.length / 3) - 1
+                            'border-b-0': rowIndex === Math.ceil(sponsors.length / 3) - 1
                           }"
                         >
                           <NuxtLink
-                            :to="value[(rowIndex * 3) + colIndex - 1].sponsorUrl"
+                            :to="sponsors[(rowIndex * 3) + colIndex - 1].sponsorUrl"
                             target="_blank"
                             class="flex items-center gap-2 justify-center h-full hover:bg-(--ui-bg-muted)/50 transition-colors"
                           >
                             <NuxtImg
-                              :src="value[(rowIndex * 3) + colIndex - 1].sponsorLogo"
-                              :alt="`${value[(rowIndex * 3) + colIndex - 1].sponsorName} logo`"
+                              :src="sponsors[(rowIndex * 3) + colIndex - 1].sponsorLogo"
+                              :alt="`${sponsors[(rowIndex * 3) + colIndex - 1].sponsorName} logo`"
                               loading="lazy"
                               class="h-10 max-w-[140px] object-contain rounded-[calc(var(--ui-radius)*2)]"
                               height="40"
                               width="40"
                             />
-                            <span class="text-base hidden sm:block font-semibold">{{ value[(rowIndex * 3) + colIndex - 1].sponsorName }}</span>
+                            <span class="text-base hidden sm:block font-semibold">{{ sponsors[(rowIndex * 3) + colIndex - 1].sponsorName }}</span>
                           </NuxtLink>
                         </td>
                         <td
@@ -589,7 +589,7 @@ onMounted(() => {
                           class="border-b border-r border-(--ui-border) p-0 w-1/3 h-[120px]"
                           :class="{
                             'border-r-0': colIndex === 3,
-                            'border-b-0': rowIndex === Math.ceil(value.length / 3) - 1
+                            'border-b-0': rowIndex === Math.ceil(sponsors.length / 3) - 1
                           }"
                         >
                           <div class="h-full" />

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -7,10 +7,9 @@ definePageMeta({
 
 const [{ data: page }, { data: officialModules }, { data: sponsors }] = await Promise.all([
   useAsyncData('index', () => queryCollection('index').first()),
-  useAsyncData('official-modules', async () => {
-    const res = await $fetch<{ modules: Module[], stats: Stats }>('https://api.nuxt.com/modules')
-
-    return res.modules
+  useFetch<{ modules: Module[], stats: Stats }>('https://api.nuxt.com/modules', {
+    key: 'official-modules',
+    transform: res => res.modules
       .filter(module => module.type === 'official')
       .sort((a, b) => b.stats.stars - a.stats.stars)
   }),


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this looks to reduce the initial payload size when visiting `https://nuxt.com`, which not only has to be loaded but also parsed.

for example, this currently includes (on every page, and therefore in every page's payload) every sponsor to nuxt and every module, even though these are used respectively only on the sponsors page and only for the search (which is, itself, lazy-loaded on the client).

#### size of index HTML document request

| before | after |
| - | - |
| 629.59K | 278.82K |