### PR TITLE
docs: rename `data` to `page` in Data Fetching code example

### DIFF
--- a/content/index.yml
+++ b/content/index.yml
@@ -115,7 +115,7 @@ hero:
 
         ```vue [pages/index.vue]
         <script setup lang="ts">
-        const { data } = await useFetch('/api/cms/home')
+        const { data: page } = await useFetch('/api/cms/home')
         </script>
 
         <template>


### PR DESCRIPTION

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

The Data Fetching code example on the homepage is missing the renaming of `data` to `page` to be available in the `<template>`. Renaming it to `page` also aligns with the blog example (`pages/blog/[slug].vue`).

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
