### PR TITLE
fix(api/feedback): requireUserSession

### DIFF
--- a/server/api/feedback/[id].delete.ts
+++ b/server/api/feedback/[id].delete.ts
@@ -6,6 +6,8 @@ const deleteParamsSchema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
+  await requireUserSession(event)
+
   const { id } = await getValidatedRouterParams(event, deleteParamsSchema.parse)
 
   const drizzle = useDrizzle()

--- a/server/api/feedback/index.get.ts
+++ b/server/api/feedback/index.get.ts
@@ -1,4 +1,6 @@
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
+  await requireUserSession(event)
+
   const drizzle = useDrizzle()
 
   return await drizzle.query.feedback.findMany()


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR addresses a critical security vulnerability where certain API endpoints were publicly accessible without requiring user authentication. Specifically, the `DELETE /api/feedback/:id` and `GET /api/feedback` endpoints were exposed, allowing any user to read or delete feedback entries without a valid session.

This change introduces `await requireUserSession(event)` to these endpoints, ensuring that only authenticated users can access them. This aligns with the intended security model and prevents unauthorized data manipulation or exposure.

The fix resolves a bug where sensitive API operations were not properly protected, enhancing the overall security of the application.
