### PR TITLE
docs(blog): update Nuxt 4 roadmap article for RC release

### DIFF
--- a/app/composables/useDocsVersion.ts
+++ b/app/composables/useDocsVersion.ts
@@ -20,10 +20,10 @@ const versions: Version[] = [{
   collection: 'docsv3'
 }, {
   label: 'Version 4',
-  tag: 'alpha',
+  tag: '4.0.0-rc', // updated from 'alpha' to '4.0.0-rc'
   shortTag: 'v4',
   branch: 'main',
-  tagColor: 'warning',
+  tagColor: 'info',
   path: '/docs/4.x',
   collection: 'docsv4'
 }]

--- a/content/blog/34.roadmap-v4.md
+++ b/content/blog/34.roadmap-v4.md
@@ -14,7 +14,8 @@ category: Release
 
 We originally planned Nuxt 4 for June 2024, but things don't always go according to plan. I think it's appropriate to take a different approach:
 
-👉 **Nuxt 4 alpha will ship June 2, 2025, with a stable release at the end of the month. Nuxt 5 will come later once Nitro v3 is ready.**
+👉 **Nuxt 4 entered Release Candidate (RC) stage on July 8, 2025, with a stable release coming soon. Nuxt 5 will come later once Nitro v3 is ready.**
+
 
 ## Why Two Releases?
 
@@ -67,10 +68,14 @@ For a while, this will mean active backports of features and bugfixes across thr
 
 ## What's Next
 
-Today we release Nuxt v4 alpha 1! We'd love early adopters to test it. Please do report issues to Nuxt or any modules that you may be using.
+Nuxt v4 is now in **Release Candidate (RC)** stage! We'd love early adopters to test it. Please do report issues to Nuxt or any modules that you may be using.
 
-::caution
-At the alpha stage, we are still planning additional breaking changes (and expect there will be bugs or 'friction'); at the beta stage, we are not planning breaking changes but they may occur if necessary. At the release candidate stage we expect only bug fixes.
+::note
+We are currently in the **release candidate stage**: no more breaking changes are planned — only bug fixes before the stable release.
+
+Release stages for Nuxt 4:
+- **Alpha**: experimental features and breaking changes
+- **RC (now)**: stable feature set, final testing before release
 ::
 
 Here's what you can expect over the next few weeks:
@@ -79,7 +84,7 @@ Here's what you can expect over the next few weeks:
 - We'll create a full **upgrade guide** for Nuxt 3 users, including a list of breaking changes and how to migrate. (The current [upgrade guide](/docs/getting-started/upgrade) explains how to enable compatibility mode, but there are some differences with Nuxt 4.)
 - We'll **only release bugfixes for v3** this month, deferring backporting new features until after the release of v4.
 - We'll **update the docs on [nuxt.com](/)** to allow switching between `3.x`, `4.x` and (soon) `5.x` documentation.
-- Once we **release the release candidate** (we're aiming for June 23) we'd love everyone to dive in again for a last round of testing. We'll only be expecting bugfixes from this point onward.
+- With the **release candidate now live**, we're focused exclusively on bug fixes. No new features or breaking changes are expected.
 - Once v4 is released, we'll separate the `main` branch to `4.x` to adopt edge releases of `h3` and `nitro` and begin development of Nuxt 5.
 
 ::note


### PR DESCRIPTION
This PR updates the **Roadmap to Nuxt 4** blog article to reflect the latest release of `v4.0.0-rc.0` (Release Candidate).

### 🔄 Changes made:
- Updated release timeline to state that Nuxt 4 entered **RC stage on July 8, 2025**
- Adjusted the `::note` block to reflect the current RC status and clarify the release progression
- Clarified the current focus on **bug fixes only** before the stable release