### PR TITLE
docs: clarify nuxt.config.ts usage

### DIFF
--- a/content/blog/11.v3-4.md
+++ b/content/blog/11.v3-4.md
@@ -89,9 +89,9 @@ In future we plan to enable build optimizations based on the metadata you pass i
 
 ## 🛠️ Easier Devtools Configuration
 
-It's even easier to enable Nuxt DevTools in your project: just set `devtools: true` in your `nuxt.config` file to enable devtools.
+It's even easier to enable Nuxt DevTools in your project: just set `devtools: true` in your `nuxt.config.ts` file to enable devtools.
 
-```js [nuxt.config.ts]
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   devtools: true
 })

--- a/content/blog/12.v3-5.md
+++ b/content/blog/12.v3-5.md
@@ -68,9 +68,9 @@ You can follow the server component roadmap at [#19772](https://github.com/nuxt/
 
 ## ⏰ Environment config
 
-You can now configure fully typed, per-environment overrides in your `nuxt.config`:
+You can now configure fully typed, per-environment overrides in your `nuxt.config.ts`:
 
-```js
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   $production: {
     routeRules: {
@@ -95,7 +95,7 @@ Out of the box, this will enable typed usage of [`navigateTo`](/docs/api/utils/n
 
 You can even get typed params within a page by using `const route = useRoute('route-name')`{lang=ts}.
 
-Enable this feature directly in your `nuxt.config`:
+Enable this feature directly in your `nuxt.config.ts`:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/content/blog/17.v3-8.md
+++ b/content/blog/17.v3-8.md
@@ -101,7 +101,7 @@ The app manifest also enables future enhancements including detection of a new d
 ::
 
 ::note
-You can **opt-on from this behaviour if you need to** by setting `experimental.appManifest` to `false` in your `nuxt.config` file.
+You can **opt-on from this behaviour if you need to** by setting `experimental.appManifest` to `false` in your `nuxt.config.ts` file.
 ::
 
 ### 🤝 Scope and Context Improvements
@@ -136,7 +136,7 @@ Once we have cross-runtime support, we will enable it by default.
 
 You can define your own [`<NuxtLink>`](/docs/api/components/nuxt-link) components with the [`defineNuxtLink`](/docs/api/components/nuxt-link#definenuxtlink-signature) utility.
 
-Today, you can cutomize the options for the built-in [`<NuxtLink>`](/docs/api/components/nuxt-link), directly in your `nuxt.config` file ([#23724](https://github.com/nuxt/nuxt/pull/23724)).
+Today, you can cutomize the options for the built-in [`<NuxtLink>`](/docs/api/components/nuxt-link), directly in your `nuxt.config.ts` file ([#23724](https://github.com/nuxt/nuxt/pull/23724)).
 
 This can enable you to enforce trailing slash behaviour across your entire site, for example:
 ```ts [nuxt.config.ts]

--- a/content/blog/25.v3-12.md
+++ b/content/blog/25.v3-12.md
@@ -16,9 +16,9 @@ We're on the road to the release of Nuxt 4, but we've not held back in Nuxt v3.1
 
 ## 🚀 Testing Nuxt 4 changes
 
-Nuxt 4 is on the horizon, and it's now possible to test out the behaviour changes that will be coming in the next major release ([#26925](https://github.com/nuxt/nuxt/pull/26925)) by setting an option in your `nuxt.config` file:
+Nuxt 4 is on the horizon, and it's now possible to test out the behaviour changes that will be coming in the next major release ([#26925](https://github.com/nuxt/nuxt/pull/26925)) by setting an option in your `nuxt.config.ts` file:
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   future: {
     compatibilityVersion: 4,

--- a/content/blog/27.v3-13.md
+++ b/content/blog/27.v3-13.md
@@ -79,7 +79,7 @@ When running with `node --enable-source-maps`, you may have noticed that the sou
 
 Now, even after your Nitro build, your server source maps will reference your original source files ([#28521](https://github.com/nuxt/nuxt/pull/28521)).
 
-Note that one of the easiest ways of improving your build performance is to turn off source maps if you aren't using them, which you can do easily in your `nuxt.config`:
+Note that one of the easiest ways of improving your build performance is to turn off source maps if you aren't using them, which you can do easily in your `nuxt.config.ts`:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/content/blog/8.nuxt-static-improvements.md
+++ b/content/blog/8.nuxt-static-improvements.md
@@ -64,7 +64,7 @@ yarn upgrade nuxt
 ```
 ::
 
-2. Ensure `target` is `static` inside your `nuxt.config`
+2. Ensure `target` is `static` inside your `nuxt.config.js`
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/deploy/vercel.md
+++ b/content/deploy/vercel.md
@@ -58,7 +58,7 @@ Read more about the Vercel KV driver on Unstorage documentation.
     npm i @vercel/kv
     ```
 
-2. Update your `nuxt.config`:
+2. Update your `nuxt.config.ts`:
 
     ```ts [nuxt.config.ts]
     export default defineNuxtConfig({
@@ -92,7 +92,7 @@ export default defineEventHandler(async (event) => {
 
 ## Custom Build Output Configuration
 
-You can provide additional [build output configuration](https://vercel.com/docs/build-output-api/v3) using `nitro.vercel.config` key inside `nuxt.config`. It will be merged with built-in auto generated config.
+You can provide additional [build output configuration](https://vercel.com/docs/build-output-api/v3) using `nitro.vercel.config` key inside `nuxt.config.ts`. It will be merged with built-in auto generated config.
 
 ## Templates
 


### PR DESCRIPTION
This PR updates references to `nuxt.config` to explicitly use `nuxt.config.ts` where applicable. It improves clarity for TypeScript users and better reflects actual usage in Nuxt projects.