### PR TITLE
docs: update Nuxt version from 4.0.0 to 4.0.1 in version selector

### DIFF
--- a/app/composables/useDocsVersion.ts
+++ b/app/composables/useDocsVersion.ts
@@ -14,7 +14,7 @@ interface Version {
 const versions: Version[] = [
   {
     label: 'Version 4',
-    tag: '4.0.0',
+    tag: '4.0.1',
     shortTag: 'v4',
     branch: 'main',
     tagColor: 'info',


### PR DESCRIPTION
### Summary

This PR updates the `Nuxt version` displayed in the documentation version selector from `4.0.0` to `4.0.1`.

### Context

Nuxt `v4.0.1` has been released. This change ensures that the docs reflect the latest stable version in the dropdown.

Let me know if any additional changes are needed.
