### PR TITLE
fix: switch docs collection definition order

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -196,17 +196,17 @@ export default defineContentConfig({
         })
       })
     }),
-    docsv3: defineCollection({
+    docsv4: defineCollection({
       type: 'page',
-      source: [docsV3Source, examplesV3Source],
+      source: [docsV4Source, examplesV4Source],
       schema: z.object({
         titleTemplate: z.string().optional(),
         links: z.array(Button)
       })
     }),
-    docsv4: defineCollection({
+    docsv3: defineCollection({
       type: 'page',
-      source: [docsV4Source, examplesV4Source],
+      source: [docsV3Source, examplesV3Source],
       schema: z.object({
         titleTemplate: z.string().optional(),
         links: z.array(Button)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This ensures that changes to files in the `v4` docs (which are the main docs now) get picked up with a higher priority than the v3 ones (which don't work locally for me anymore).

Tbh, I'm not sure if this is the correct solution since I haven't used Nuxt content a lot, but it seems to have solved the issue for me locally.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
