### PR TITLE
docs: correct edit page link for deploy section

### DIFF
--- a/app/pages/deploy/[slug].vue
+++ b/app/pages/deploy/[slug].vue
@@ -62,7 +62,7 @@ if (provider.value?.nitroPreset) {
 links.push({
   icon: 'i-lucide-pen',
   label: 'Edit this page',
-  to: `https://github.com/nuxt/nuxt.com/edit/main/content/3.deploy/${route.params.slug}.md`,
+  to: `https://github.com/nuxt/nuxt.com/edit/main/content/deploy/${route.params.slug}.md`,
   target: '_blank'
 })
 </script>


### PR DESCRIPTION
### 🔗 Linked issue

N/A. This is a minor, self-evident fix for a broken link.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request corrects the URL for the "Edit this page" link on the deployment documentation pages.

Currently, the generated link has an incorrect path (`/content/3.deploy/...`) which leads to a 404 error on GitHub. This prevents users from easily suggesting improvements to that part of the docs.

This change removes the erroneous `3.` prefix from the path construction, ensuring the link correctly points to `/content/deploy/...`.