### PR TITLE
fix: use `useAsyncData` as the source of truth

### DIFF
--- a/app/composables/useEnterpriseAgencies.ts
+++ b/app/composables/useEnterpriseAgencies.ts
@@ -3,19 +3,12 @@ import { slugify, random } from '../utils'
 
 export const useEnterpriseAgencies = () => {
   const route = useRoute()
-  const agencies = useState<Agency[]>('enterprise-agencies', () => [])
-
-  // Data fetching
-  async function fetchList() {
-    if (agencies.value.length) {
-      return
-    }
-
-    try {
-      const { data: agenciesData } = await useAsyncData('agencies', () => queryCollection('agencies').all())
-
-      if (agenciesData.value && Array.isArray(agenciesData.value)) {
-        agencies.value = agenciesData.value.map((agency: any) => ({
+  const { data: agencies, execute } = useAsyncData('agencies', () => queryCollection('agencies').all(), {
+    immediate: false,
+    default: () => [],
+    transform: (data) => {
+      if (data && Array.isArray(data)) {
+        return data.map((agency: any) => ({
           ...agency,
           services: (agency.services || []).map((service: string) => ({
             key: slugify(service),
@@ -33,10 +26,17 @@ export const useEnterpriseAgencies = () => {
             : null
         })) as Agency[]
       }
-    } catch (e) {
-      agencies.value = []
-      return e
+      return []
     }
+  })
+
+  // Data fetching
+  async function fetchList() {
+    if (agencies.value.length) {
+      return
+    }
+
+    return execute()
   }
 
   // Computed

--- a/app/composables/useEnterpriseJobs.ts
+++ b/app/composables/useEnterpriseJobs.ts
@@ -3,7 +3,17 @@ import { toRelativeDate } from '../utils'
 
 export const useEnterpriseJobs = () => {
   const route = useRoute()
-  const jobs = useState<Job[]>('jobs', () => [])
+  const { data: jobs, execute } = useAsyncData('jobs', () => $fetch<Job[]>('https://api.nuxt.com/jobs'), {
+    immediate: false,
+    default: () => [],
+    transform: (data) => {
+      return data.map(job => ({
+        ...job,
+        remote: mapRemote(job.remote),
+        published_at: toRelativeDate(job.published_at)
+      }))
+    }
+  })
 
   const mapRemote = (remoteType: string) => {
     switch (remoteType) {
@@ -23,11 +33,7 @@ export const useEnterpriseJobs = () => {
       return
     }
 
-    const res = await $fetch<Job[]>('https://api.nuxt.com/jobs')
-
-    jobs.value = res.map((job) => {
-      return { ...job, remote: mapRemote(job.remote), published_at: toRelativeDate(job.published_at) }
-    })
+    return execute()
   }
 
   // Computed

--- a/app/composables/useHostingProviders.ts
+++ b/app/composables/useHostingProviders.ts
@@ -1,21 +1,16 @@
-import type { DeployCollectionItem } from '@nuxt/content'
-
 export const useHostingProviders = () => {
-  const providers = useState<DeployCollectionItem[]>('hostingProviders', () => [])
+  const { data: providers, execute } = useAsyncData(() => queryCollection('deploy').all(), {
+    immediate: false,
+    default: () => [],
+    transform: data => data.filter(article => article.path !== '/deploy')
+  })
 
   async function fetchList() {
     if (providers.value.length) {
       return
     }
 
-    try {
-      const { data } = await useAsyncData('hosting-provider', () => queryCollection('deploy').all())
-
-      providers.value = data.value?.filter(article => article.path !== '/deploy') || []
-    } catch (e) {
-      providers.value = []
-      return e
-    }
+    return execute()
   }
 
   return {

--- a/app/composables/useModules.ts
+++ b/app/composables/useModules.ts
@@ -53,8 +53,8 @@ export const useModules = () => {
     })
   })
 
-  const stats = computed(() => data.value?.stats || {})
-  const modules = computed(() => data.value?.modules || [])
+  const stats = computed(() => data.value.stats)
+  const modules = computed(() => data.value.modules || [])
 
   const module = useState<Module>('module', () => ({} as Module))
 

--- a/app/composables/useModules.ts
+++ b/app/composables/useModules.ts
@@ -41,12 +41,21 @@ export const moduleIcon = function (category: string) {
 export const useModules = () => {
   const route = useRoute()
   const router = useRouter()
-  const stats = useState<Stats>('module-stats', () => ({
-    maintainers: 0,
-    contributors: 0,
-    modules: 0
-  }))
-  const modules = useState<Module[]>('modules', () => [])
+  const { data, execute } = useFetch<{ modules: Module[], stats: Stats }>('https://api.nuxt.com/modules', {
+    immediate: false,
+    default: () => ({
+      modules: [],
+      stats: {
+        maintainers: 0,
+        contributors: 0,
+        modules: 0
+      }
+    })
+  })
+
+  const stats = computed(() => data.value?.stats || {})
+  const modules = computed(() => data.value?.modules || [])
+
   const module = useState<Module>('module', () => ({} as Module))
 
   // Data fetching
@@ -55,11 +64,7 @@ export const useModules = () => {
       return
     }
 
-    const res = await $fetch<{ modules: Module[], stats: Stats }>('https://api.nuxt.com/modules')
-    if (res?.modules) {
-      modules.value = res.modules
-      stats.value = res.stats
-    }
+    return execute()
   }
 
   // Data


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

spotted this when looking at something else - this reduces the size of the HTML by about 300kb because we don't need to have the data stored in both state + payload

additionally, `useAsyncData` should never be called _within_ a fetcher function; rather, it _exposes_ a fetcher function that can be called as desired