### PR TITLE
docs: update link for TypeScript plugin documentation

### DIFF
--- a/content/blog/40.v4-2.md
+++ b/content/blog/40.v4-2.md
@@ -159,8 +159,8 @@ This module adds a number of TypeScript plugins that aim to improve your experie
 - **Runtime config navigation**: Go to definition works seamlessly with runtime config properties
 - **Enhanced auto-import support**: Includes the [`@dxup/unimport`](https://github.com/KazariEX/dxup/tree/main/packages/unimport) plugin for better navigation with auto-imported composables and utilities
 
-::note{to="#typescript-plugin"}
-Read more in **[the documentation](/docs/guide/directory-structure/nuxt-config#typescript-plugin)**.
+::note{to="/docs/guide/going-further/experimental-features#typescriptplugin"}
+Read more in **[the documentation](/docs/guide/going-further/experimental-features#typescriptplugin)**.
 ::
 
 To enable this feature, set `experimental.typescriptPlugin` to `true` in your Nuxt configuration:


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The link to the new typescript plugin is wrong, click on the exist one can only add a `#typescript-plugin` to the current url.

Also I believe the document of this should be in `/docs/guide/going-further/experimental-features#typescriptplugin` but not `/docs/guide/directory-structure/nuxt-config#typescript-plugin`.
