### PR TITLE
Remove duplicate refresh() call

### DIFF
--- a/content/blog/40.v4-2.md
+++ b/content/blog/40.v4-2.md
@@ -27,8 +27,6 @@ const { data, error, clear, refresh } = await useAsyncData('users', (_nuxtApp, {
 }))
 
 refresh() // will actually cancel the $fetch request (if dedupe: cancel)
-refresh() // will actually cancel the $fetch request (if dedupe: cancel)
-refresh()
   
 clear() // will cancel the latest pending handler
 </script>


### PR DESCRIPTION
Removed duplicate refresh() call in the script section.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

I don't think it needs to show `refresh()` three times in example :)
https://nuxt.com/blog/v4-2

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
