### PR TITLE
fix(useNavigation): remove onMounted call from computed

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -2,7 +2,8 @@
 const colorMode = useColorMode()
 const { version } = useDocsVersion()
 const { searchGroups, searchLinks, searchTerm } = useNavigation()
-const { fetchList } = useModules()
+const { fetchList: fetchModules } = useModules()
+const { fetchList: fetchHosting } = useHostingProviders()
 
 const color = computed(() => colorMode.value === 'dark' ? '#020420' : 'white')
 
@@ -30,7 +31,10 @@ const [{ data: navigation }, { data: files }] = await Promise.all([
   })
 ])
 
-onNuxtReady(() => fetchList())
+onNuxtReady(() => {
+  fetchModules()
+  fetchHosting()
+})
 
 useHead({
   titleTemplate: title => title ? `${title} · Nuxt` : 'Nuxt: The Intuitive Web Framework',

--- a/app/composables/useNavigation.ts
+++ b/app/composables/useNavigation.ts
@@ -163,6 +163,8 @@ const _useNavigation = () => {
 
   const { headerLinks } = useHeaderLinks()
   const { footerLinks } = useFooterLinks()
+  const { modules } = useModules()
+  const { providers } = useHostingProviders()
 
   const searchLinks = computed(() => [
     {
@@ -251,59 +253,38 @@ const _useNavigation = () => {
       }
     }]
 
-    const loadModules = async () => {
-      const { modules, fetchList } = useModules()
-      if (!modules.value.length) {
-        await fetchList()
-      }
+    modulesGroup.items = modules.value
+      .filter(module => ['name', 'npm', 'repo'].map(field => module[field as keyof typeof module]).filter(Boolean).some(value => typeof value === 'string' && value.search(searchTextRegExp(searchTerm.value)) !== -1))
+      .map(module => ({
+        id: `module-${module.name}`,
+        label: module.npm,
+        suffix: module.description,
+        avatar: {
+          src: moduleImage(module.icon),
+          ui: {
+            root: 'rounded-none bg-transparent'
+          }
+        },
+        to: `/modules/${module.name}`
+      }))
 
-      modulesGroup.items = modules.value
-        .filter(module => ['name', 'npm', 'repo'].map(field => module[field as keyof typeof module]).filter(Boolean).some(value => typeof value === 'string' && value.search(searchTextRegExp(searchTerm.value)) !== -1))
-        .map(module => ({
-          id: `module-${module.name}`,
-          label: module.npm,
-          suffix: module.description,
-          avatar: {
-            src: moduleImage(module.icon),
-            ui: {
-              root: 'rounded-none bg-transparent'
-            }
-          },
-          to: `/modules/${module.name}`
-        }))
-    }
-
-    const loadHosting = async () => {
-      const { providers, fetchList } = useHostingProviders()
-      if (!providers.value.length) {
-        await fetchList()
-      }
-
-      hostingGroup.items = providers.value
-        .filter(hosting => ['title'].map(field => hosting[field as keyof typeof hosting]).filter(Boolean).some(value => typeof value === 'string' && value.search(searchTextRegExp(searchTerm.value)) !== -1))
-        .map(hosting => ({
-          id: `hosting-${hosting.path}`,
-          label: hosting.title,
-          suffix: hosting.description,
-          icon: hosting.logoIcon,
-          avatar: hosting.logoSrc
-            ? {
-                src: hosting.logoSrc,
-                ui: {
-                  root: 'rounded-none bg-transparent'
-                }
+    hostingGroup.items = providers.value
+      .filter(hosting => ['title'].map(field => hosting[field as keyof typeof hosting]).filter(Boolean).some(value => typeof value === 'string' && value.search(searchTextRegExp(searchTerm.value)) !== -1))
+      .map(hosting => ({
+        id: `hosting-${hosting.path}`,
+        label: hosting.title,
+        suffix: hosting.description,
+        icon: hosting.logoIcon,
+        avatar: hosting.logoSrc
+          ? {
+              src: hosting.logoSrc,
+              ui: {
+                root: 'rounded-none bg-transparent'
               }
-            : undefined,
-          to: hosting.path
-        }))
-    }
-
-    onMounted(() => {
-      Promise.all([
-        loadModules(),
-        loadHosting()
-      ]).catch(error => console.error('Error loading search results:', error))
-    })
+            }
+          : undefined,
+        to: hosting.path
+      }))
 
     return groups
   })

--- a/app/error.vue
+++ b/app/error.vue
@@ -11,7 +11,8 @@ defineProps<{ error: NuxtError }>()
 const route = useRoute()
 const { version } = useDocsVersion()
 const { searchGroups, searchLinks, searchTerm } = useNavigation()
-const { fetchList } = useModules()
+const { fetchList: fetchModules } = useModules()
+const { fetchList: fetchHosting } = useHostingProviders()
 
 const [{ data: navigation }, { data: files }] = await Promise.all([
   useAsyncData('navigation', () => {
@@ -37,7 +38,10 @@ const [{ data: navigation }, { data: files }] = await Promise.all([
   })
 ])
 
-onNuxtReady(() => fetchList())
+onNuxtReady(() => {
+  fetchModules()
+  fetchHosting()
+})
 
 const versionNavigation = computed(() => navigation.value?.filter(item => item.path === version.value.path || item.path === '/blog') ?? [])
 const versionFiles = computed(() => files.value?.filter((file) => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There was an issue where `onMounted` was called inside `searchGroups` computed inside `useNavigation()` which caused this warning:

```
[Vue warn]: onMounted is called when there is no active component instance to be associated with. Lifecycle injection APIs can only be used during execution of setup(). If you are using async setup(), make sure to register lifecycle hooks before the first await statement. 
```
