### PR TITLE
fix(modules): prevent ISR from caching 404 error responses

### DIFF
--- a/app/pages/modules/index.vue
+++ b/app/pages/modules/index.vue
@@ -15,8 +15,13 @@ const { replaceRoute } = useFilters('modules')
 const { fetchList, filteredModules, q, categories, modules, stats, selectedSort, selectedOrder, selectedCategory, sorts } = useModules()
 const { track } = useAnalytics()
 
+const cacheControl = useResponseHeader('Cache-Control')
+const cdnCacheControl = useResponseHeader('CDN-Cache-Control')
+
 const { data: page } = await useAsyncData('modules-landing', () => queryCollection('landing').path('/modules').first())
 if (!page.value) {
+  cacheControl.value = 'no-store, no-cache, must-revalidate'
+  cdnCacheControl.value = 'no-store'
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 


### PR DESCRIPTION
Resolves #2148, #2140

## Problem
The `/modules` page intermittently returns 404 errors when accessed directly. The issue occurs because:
1. The page uses ISR with 1-hour cache
2. When `queryCollection('landing').path('/modules')` transiently fails, a 404 is thrown
3. ISR caches the 404 response, causing persistent failures until cache expires

## Solution
Set `Cache-Control` and `CDN-Cache-Control` headers to `no-store` before throwing the 404 error, preventing ISR from caching the error response.