### PR TITLE
Refactor getImage function to use defineProvider

### DIFF
--- a/content/blog/41.nuxt-image-v2.md
+++ b/content/blog/41.nuxt-image-v2.md
@@ -191,7 +191,6 @@ The biggest breaking change is how providers are defined. All providers now use 
 ```diff
 - export const getImage = (src, { modifiers }) => { ... }
 + export default defineProvider({
-+   name: 'my-provider',
 +   getImage(src, { modifiers }) { ... }
 + })
 ```


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I don't think it is correct `defineProvider` should have a `name` property in Nuxt Image v2 and it isn't mentioned elsewhere: https://image.nuxt.com/get-started/migration

Furthermore the type doesn't show any name property:

<img width="469" height="118" alt="image" src="https://github.com/user-attachments/assets/b8cf1bcf-019f-4796-b363-cfe108ff8cba" />

and it doesn't seem any of the default providers are using this:
https://github.com/nuxt/image/tree/main/src/runtime/providers

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
