### PR TITLE
docs: update cloudflare deployment docs link

### DIFF
--- a/content/deploy/cloudflare.md
+++ b/content/deploy/cloudflare.md
@@ -122,6 +122,6 @@ Head over **CloudFlare Pages** documentation to learn more about it.
 
 ## Learn more
 
-::read-more{to="https://nitro.unjs.io/deploy/providers/cloudflare" target="_blank"}
+::read-more{to="https://v2.nitro.build/deploy/providers/cloudflare" target="_blank"}
 Head over **Nitro documentation** to learn more about the cloudflare deployment preset.
 ::


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2225

### 📚 Description

Nuxt 4 uses nitro 2 which configures bindings very differently to nitro 3, which is why it's better to link to the old docs.
