### PR TITLE
fix(search): improve grouping and relevance

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -3,8 +3,6 @@ const colorMode = useColorMode()
 const route = useRoute()
 const isChatRoute = computed(() => route.path === '/chat' || route.path.startsWith('/chat/'))
 const { version } = useDocsVersion()
-const { fetchList: fetchModules } = useModules()
-const { fetchList: fetchHosting } = useHostingProviders()
 const { track } = useAnalytics()
 
 const color = computed(() => colorMode.value === 'dark' ? '#020420' : 'white')
@@ -16,11 +14,6 @@ watch(() => colorMode.preference, (newMode, oldMode) => {
 })
 
 const { data: navigation } = await useFetch('/api/navigation.json')
-
-onNuxtReady(() => {
-  fetchModules()
-  fetchHosting()
-})
 
 useHead({
   titleTemplate: title => title ? `${title} · Nuxt` : 'Nuxt: The Intuitive Web Framework',

--- a/app/components/Search.vue
+++ b/app/components/Search.vue
@@ -14,9 +14,16 @@ const { status, search, init } = useSearchCollection(collections, {
   ignoredTags: ['style']
 })
 
-const { searchGroups, searchLinks, searchTerm, searchFuse } = useNavigation()
+const { searchGroups, searchLinks, searchTerm } = useNavigation()
 const { open } = useContentSearch()
 const { track } = useAnalytics()
+
+const fuse = {
+  resultLimit: 25,
+  fuseOptions: {
+    useTokenSearch: false
+  }
+}
 
 watch(open, (value) => {
   if (value && status.value === 'idle') {
@@ -39,6 +46,6 @@ watchDebounced(searchTerm, (term) => {
     :navigation="navigation"
     :search="search"
     :search-status="status"
-    :fuse="searchFuse"
+    :fuse="fuse"
   />
 </template>

--- a/app/components/Search.vue
+++ b/app/components/Search.vue
@@ -7,9 +7,9 @@ defineProps<{
 
 const { version } = useDocsVersion()
 
-const collections = computed(() => [version.value.collection, 'blog' as const].filter(Boolean))
+const collection = computed(() => version.value.collection)
 
-const { status, search, init } = useSearchCollection(collections, {
+const { status, search, init } = useSearchCollection(collection, {
   immediate: false,
   ignoredTags: ['style']
 })
@@ -47,5 +47,6 @@ watchDebounced(searchTerm, (term) => {
     :search="search"
     :search-status="status"
     :fuse="fuse"
+    :transition="false"
   />
 </template>

--- a/app/components/Search.vue
+++ b/app/components/Search.vue
@@ -40,6 +40,5 @@ watchDebounced(searchTerm, (term) => {
     :search="search"
     :search-status="status"
     :fuse="searchFuse"
-    :transition="false"
   />
 </template>

--- a/app/components/Search.vue
+++ b/app/components/Search.vue
@@ -40,5 +40,6 @@ watchDebounced(searchTerm, (term) => {
     :search="search"
     :search-status="status"
     :fuse="searchFuse"
+    :transition="false"
   />
 </template>

--- a/app/components/agent/AgentChatButton.vue
+++ b/app/components/agent/AgentChatButton.vue
@@ -9,7 +9,7 @@ function handleToggle() {
 </script>
 
 <template>
-  <UTooltip text="Agent">
+  <UTooltip text="Agent" :kbds="['meta', 'I']" ignore-non-keyboard-focus>
     <UButton
       icon="i-custom-ai"
       color="neutral"

--- a/app/components/agent/AgentPanel.vue
+++ b/app/components/agent/AgentPanel.vue
@@ -18,7 +18,9 @@ const { chat, input, votes, vote, canClear, onSubmit, askQuestion, clearMessages
 
 const panelUi = {
   footer: 'p-0',
-  actions: 'gap-0.5'
+  actions: 'gap-0.5',
+  gap: 'transition-none',
+  container: 'transition-none'
 } as const
 
 /* Slideover theme defaults add sm:px-6 / sm:p-6; override so layout matches USidebar (full width inside panel) */

--- a/app/components/agent/AgentPanel.vue
+++ b/app/components/agent/AgentPanel.vue
@@ -18,9 +18,7 @@ const { chat, input, votes, vote, canClear, onSubmit, askQuestion, clearMessages
 
 const panelUi = {
   footer: 'p-0',
-  actions: 'gap-0.5',
-  gap: 'transition-none',
-  container: 'transition-none'
+  actions: 'gap-0.5'
 } as const
 
 /* Slideover theme defaults add sm:px-6 / sm:p-6; override so layout matches USidebar (full width inside panel) */

--- a/app/components/header/Header.vue
+++ b/app/components/header/Header.vue
@@ -65,7 +65,7 @@ function trackGitHubClick() {
     />
 
     <template #right>
-      <UTooltip text="Search" :kbds="['meta', 'K']">
+      <UTooltip text="Search" :kbds="['meta', 'K']" ignore-non-keyboard-focus>
         <UContentSearchButton @click="trackSearchOpen" />
       </UTooltip>
 

--- a/app/composables/useNavigation.ts
+++ b/app/composables/useNavigation.ts
@@ -1,15 +1,6 @@
 import type { CommandPaletteGroup } from '@nuxt/ui'
 import { createSharedComposable } from '@vueuse/core'
 
-// Stable reference so the deep watcher inside `useFuse` doesn't rebuild
-// the entire Fuse index on every reactive flush.
-const searchFuse = {
-  resultLimit: 25,
-  fuseOptions: {
-    threshold: 0
-  }
-}
-
 function _useHeaderLinks() {
   const route = useRoute()
   const { version } = useDocsVersion()
@@ -302,8 +293,7 @@ const _useNavigation = () => {
     headerLinks,
     footerLinks,
     searchLinks,
-    searchGroups,
-    searchFuse
+    searchGroups
   }
 }
 

--- a/app/composables/useNavigation.ts
+++ b/app/composables/useNavigation.ts
@@ -175,8 +175,9 @@ const _useNavigation = () => {
 
   const { headerLinks } = useHeaderLinks()
   const { footerLinks } = useFooterLinks()
-  const { modules } = useModules()
-  const { providers } = useHostingProviders()
+  const { modules, fetchList: fetchModules } = useModules()
+  const { providers, fetchList: fetchHosting } = useHostingProviders()
+  const { articles: blogArticles, fetchList: fetchBlog } = useBlog()
 
   const searchLinks = computed(() => [{
     label: 'Ask Agent',
@@ -247,30 +248,41 @@ const _useNavigation = () => {
     to: hosting.path
   })))
 
+  const blogItems = computed(() => blogArticles.value.map(article => ({
+    id: `blog-${article.path}`,
+    label: article.title,
+    suffix: article.description,
+    icon: 'i-lucide-newspaper',
+    to: article.path
+  })))
+
+  const postFilter = (searchTerm: string, items: any[]) => {
+    if (!searchTerm) {
+      return []
+    }
+    return items
+  }
+
   const searchGroups = computed<CommandPaletteGroup[]>(() => [{
     id: 'modules-search',
     label: 'Modules',
     items: modulesItems.value,
-    postFilter: (searchTerm: string, items: any[]) => {
-      if (!searchTerm) {
-        return [...items].sort((a, b) => (b.downloads ?? 0) - (a.downloads ?? 0))
-      }
-      return items
-    }
+    postFilter
   }, {
     id: 'hosting-search',
     label: 'Hosting',
-    items: hostingItems.value
+    items: hostingItems.value,
+    postFilter
+  }, {
+    id: 'blog-search',
+    label: 'Blog',
+    items: blogItems.value,
+    postFilter
   }, {
     id: 'ask-ai-search',
     label: 'AI',
     ignoreFilter: true,
-    postFilter: (searchTerm: string, items: any[]) => {
-      if (!searchTerm) {
-        return []
-      }
-      return items
-    },
+    postFilter,
     items: [{
       label: 'Ask Agent',
       icon: 'i-lucide-wand',
@@ -281,6 +293,15 @@ const _useNavigation = () => {
       }
     }]
   }])
+
+  const { open: searchOpen } = useContentSearch()
+  watch(searchOpen, (value) => {
+    if (value) {
+      fetchModules()
+      fetchHosting()
+      fetchBlog()
+    }
+  })
 
   watchDebounced(searchTerm, (term) => {
     if (term) {

--- a/app/error.vue
+++ b/app/error.vue
@@ -10,15 +10,8 @@ defineProps<{ error: NuxtError }>()
 
 const route = useRoute()
 const { version } = useDocsVersion()
-const { fetchList: fetchModules } = useModules()
-const { fetchList: fetchHosting } = useHostingProviders()
 
 const { data: navigation } = await useFetch('/api/navigation.json')
-
-onNuxtReady(() => {
-  fetchModules()
-  fetchHosting()
-})
 
 const versionNavigation = computed(() => navigation.value?.filter(item => item.path === version.value.path || item.path === '/blog') ?? [])
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

- Search docs only via FTS, add blog as a separate fuse-filtered group
- Hide fuse groups (modules, hosting, blog) when no query is entered
- Lazy-load modules, hosting and blog data on search open instead of page load
- Disable token search and drop strict `threshold: 0` for better FTS relevance
- Disable search modal transition for snappier open/close
- Add `ignore-non-keyboard-focus` to search and agent tooltips
- Show `⌘I` keyboard shortcut in agent tooltip

