### PR TITLE
feat(showcase): add 6 production Nuxt sites by Ikki Studio

### DIFF
--- a/content/showcase.yml
+++ b/content/showcase.yml
@@ -159,5 +159,17 @@ websites:
     delay: 5
   - name: Shaina Mote
     url: https://www.shainamote.com/
+  - name: Codemachia
+    url: https://codemachia.com/
+  - name: Ikki
+    url: https://ikki.io/
+  - name: The Boom
+    url: https://the-boom.org/
+  - name: Maideo
+    url: https://maideo.fr/
+  - name: Opportunix
+    url: https://www.opportunix.org/
+  - name: footfoot
+    url: https://www.footfoot.co/  
     screenshotOptions:
       hideElements: ['.cookie-policy', '.announcement-bar']

--- a/content/showcase.yml
+++ b/content/showcase.yml
@@ -159,6 +159,8 @@ websites:
     delay: 5
   - name: Shaina Mote
     url: https://www.shainamote.com/
+    screenshotOptions:
+      hideElements: ['.cookie-policy', '.announcement-bar']    
   - name: Codemachia
     url: https://codemachia.com/
   - name: Ikki
@@ -171,5 +173,3 @@ websites:
     url: https://www.opportunix.org/
   - name: footfoot
     url: https://www.footfoot.co/  
-    screenshotOptions:
-      hideElements: ['.cookie-policy', '.announcement-bar']


### PR DESCRIPTION
### Linked issue

N/A — showcase additions (data file only).

### Description

Adding 6 production websites built entirely with Nuxt 3 by Ikki Studio (Paris, 3 people, no VC):

- **Codemachia** (https://codemachia.com) — AI-native transmedia sci-fi universe with Three.js + ElevenLabs, bilingual EN/FR
- **Ikki** (https://ikki.io) — the studio site itself, end-to-end Nuxt with a live voice agent demo
- **The Boom** (https://the-boom.org) — multi-tenant party PWA, Spotify-backed
- **Maideo** (https://maideo.fr) — B2C home-services SaaS, SSR across 34k+ commune pages
- **Opportunix** (https://www.opportunix.org) — B2B AI platform for French public tenders
- **footfoot** (https://www.footfoot.co) — skill-based football prediction game, multilingual

All six are live in production and have been for some time. All built by the same 3-person studio.

### Note on the second commit

The first commit added the 6 new entries but accidentally split Shaina Mote's entry (her `screenshotOptions` block ended up at the bottom of the file, attached to the wrong entry). The second commit restores it to its correct position under her URL. No other existing entries are modified.

### Checklist

- [x] PR title follows conventional commits (`feat(showcase): …`)
- [x] No duplicate PR exists for these sites
- [x] Read contribution docs
- [x] No tests applicable (data file only)
- [x] All URLs are live, production sites built with Nuxt