### PR TITLE
fix: address vite doctor diagnostics

### DIFF
--- a/app/components/AdminDashboard.vue
+++ b/app/components/AdminDashboard.vue
@@ -320,7 +320,7 @@ watch(currentPage, () => {
   if (feedbackContainer.value) {
     feedbackContainer.value.scrollTop = 0
   }
-})
+}, { flush: 'post' })
 </script>
 
 <template>

--- a/app/components/chat/ChatPanel.vue
+++ b/app/components/chat/ChatPanel.vue
@@ -126,6 +126,7 @@ const suggestions = [
             <button
               v-for="suggestion in suggestions"
               :key="suggestion.title"
+              type="button"
               class="flex sm:flex-col gap-3 p-4 rounded-lg border border-default bg-default hover:bg-elevated/50 text-left transition-colors cursor-pointer"
               @click="askQuestion(suggestion.question)"
             >

--- a/app/composables/useCanonical.ts
+++ b/app/composables/useCanonical.ts
@@ -10,7 +10,7 @@ export function useCanonical(markdownAlternate?: MaybeRefOrGetter<string | null 
   const route = useRoute()
   const site = useSiteConfig()
 
-  useHead({
+  useHeadSafe({
     link: computed(() => {
       const links: Link[] = [
         { rel: 'canonical', href: joinURL(site.url, route.path) }

--- a/app/composables/useDateRange.ts
+++ b/app/composables/useDateRange.ts
@@ -5,16 +5,29 @@ export interface DateRange {
   end: Date
 }
 
+interface SerializedDateRange {
+  start: string
+  end: string
+}
+
 export function useDateRange() {
-  const dateRange = useState<DateRange>('feedback-date-range', () => ({
-    start: subDays(new Date(), 30),
-    end: new Date()
+  const serializedDateRange = useState<SerializedDateRange>('feedback-date-range', () => {
+    const end = endOfDay(new Date())
+    return {
+      start: startOfDay(subDays(end, 30)).toISOString(),
+      end: end.toISOString()
+    }
+  })
+
+  const dateRange = computed<DateRange>(() => ({
+    start: new Date(serializedDateRange.value.start),
+    end: new Date(serializedDateRange.value.end)
   }))
 
   const setDateRange = (range: DateRange) => {
-    dateRange.value = {
-      start: startOfDay(range.start),
-      end: endOfDay(range.end)
+    serializedDateRange.value = {
+      start: startOfDay(range.start).toISOString(),
+      end: endOfDay(range.end).toISOString()
     }
   }
 

--- a/app/composables/useSponsors.ts
+++ b/app/composables/useSponsors.ts
@@ -1,10 +1,8 @@
 import type { Sponsor } from '#shared/types'
 
-export const useSponsors = async () => {
-  const [{ data: apiSponsors }, { data: manualSponsors }] = await Promise.all([
-    useFetch('/api/sponsors', { key: 'sponsors' }),
-    useAsyncData('manual-sponsors', () => queryCollection('manualSponsors').first())
-  ])
+export const useSponsors = () => {
+  const { data: apiSponsors } = useFetch('/api/sponsors', { key: 'sponsors' })
+  const { data: manualSponsors } = useAsyncData('manual-sponsors', () => queryCollection('manualSponsors').first())
 
   const sponsors = computed(() => {
     const manual = manualSponsors.value?.sponsors || []

--- a/app/pages/deploy/index.vue
+++ b/app/pages/deploy/index.vue
@@ -62,7 +62,14 @@ await fetchList()
             }"
           >
             <template #leading>
-              <NuxtImg v-if="deployment.logoSrc" :src="deployment.logoSrc" width="40" height="40" class="w-10 h-10" />
+              <NuxtImg
+                v-if="deployment.logoSrc"
+                :src="deployment.logoSrc"
+                :alt="`${deployment.title} logo`"
+                width="40"
+                height="40"
+                class="w-10 h-10"
+              />
               <UIcon v-else :name="deployment.logoIcon" class="size-10 text-black dark:text-white" />
             </template>
             <UBadge

--- a/app/pages/modules/index.vue
+++ b/app/pages/modules/index.vue
@@ -91,7 +91,7 @@ watch(scrollY, (y) => {
   if (window.innerHeight + y >= document.documentElement.scrollHeight - SCROLL_THRESHOLD) {
     debouncedLoadMore()
   }
-})
+}, { flush: 'post' })
 
 watch(filteredModules, () => {
   isLoading.value = false

--- a/app/pages/video-courses.vue
+++ b/app/pages/video-courses.vue
@@ -45,6 +45,7 @@ defineOgImage('Docs.takumi', {
               :alt="course.name"
               :width="'sponsor' in course && course.sponsor ? 94 : 56"
               :height="'sponsor' in course && course.sponsor ? 47 : 28"
+              :sizes="'sponsor' in course && course.sponsor ? '94px' : '56px'"
               format="webp"
               :modifiers="{ position: 'top' }"
               :loading="index > 3 ? 'lazy' : undefined"

--- a/server/api/admin/mcp-install.get.ts
+++ b/server/api/admin/mcp-install.get.ts
@@ -1,7 +1,7 @@
 export default defineEventHandler(async (event) => {
   const { user } = await requireUserSession(event)
 
-  if (!user?.login || !(await isAuthorizedAdmin(user.login))) {
+  if (!user?.login || !(await isAuthorizedAdmin(event, user.login))) {
     throw createError({ statusCode: 403, statusMessage: 'Admin access required' })
   }
 

--- a/server/api/auth/github.get.ts
+++ b/server/api/auth/github.get.ts
@@ -1,6 +1,6 @@
 export default defineOAuthGitHubEventHandler({
   async onSuccess(event, { user }) {
-    const allowed = await isAuthorizedAdmin(user.login)
+    const allowed = await isAuthorizedAdmin(event, user.login)
 
     if (!allowed) {
       return sendRedirect(event, '/admin/login?error=access-denied')

--- a/server/api/v1/teams/index.get.ts
+++ b/server/api/v1/teams/index.get.ts
@@ -1,9 +1,9 @@
 import type { GitHubTeamMember } from '../../../types/github'
 
-export default defineCachedEventHandler(async () => {
+export default defineCachedEventHandler(async (event) => {
   const [core, _ecosystem] = await Promise.all([
-    $fetch<GitHubTeamMember[]>('/api/v1/teams/core'),
-    $fetch<GitHubTeamMember[]>('/api/v1/teams/ecosystem')
+    event.$fetch<GitHubTeamMember[]>('/api/v1/teams/core'),
+    event.$fetch<GitHubTeamMember[]>('/api/v1/teams/ecosystem')
   ])
 
   const filteredEcosystem = [] as GitHubTeamMember[]

--- a/server/utils/team.ts
+++ b/server/utils/team.ts
@@ -1,12 +1,13 @@
 import type { GitHubTeamMember } from '../types/github'
+import type { H3Event } from 'h3'
 
-const getCoreMembers = cachedFunction((): Promise<GitHubTeamMember[]> => $fetch<GitHubTeamMember[]>('/api/v1/teams/core'), {
+const getCoreMembers = cachedFunction((event: H3Event): Promise<GitHubTeamMember[]> => event.$fetch<GitHubTeamMember[]>('/api/v1/teams/core'), {
   maxAge: 60 * 60 * 24 * 7, // 1 week
   getKey: () => 'core-members'
 })
 
-export async function isCoreTeamMember(login: string): Promise<boolean> {
-  const coreMembers = await getCoreMembers()
+export async function isCoreTeamMember(event: H3Event, login: string): Promise<boolean> {
+  const coreMembers = await getCoreMembers(event)
   if (!coreMembers || !Array.isArray(coreMembers)) {
     throw createError({
       statusCode: 500,
@@ -16,8 +17,8 @@ export async function isCoreTeamMember(login: string): Promise<boolean> {
   return coreMembers.some(member => member.login.toLowerCase() === login)
 }
 
-function getExtraAdminLogins(): string[] {
-  const raw = useRuntimeConfig().adminGithubLogins
+function getExtraAdminLogins(event: H3Event): string[] {
+  const raw = useRuntimeConfig(event).adminGithubLogins
   if (!raw) return []
   return raw
     .split(',')
@@ -25,10 +26,10 @@ function getExtraAdminLogins(): string[] {
     .filter(Boolean)
 }
 
-export async function isAuthorizedAdmin(login: string): Promise<boolean> {
+export async function isAuthorizedAdmin(event: H3Event, login: string): Promise<boolean> {
   const normalized = login.toLowerCase()
-  if (getExtraAdminLogins().includes(normalized)) {
+  if (getExtraAdminLogins(event).includes(normalized)) {
     return true
   }
-  return isCoreTeamMember(normalized)
+  return isCoreTeamMember(event, normalized)
 }


### PR DESCRIPTION
This is an experiment from running the Vite Doctor CLI against nuxt.com. The project rules are documented at https://vite-doctor.onmax.me/nuxt/rules.

I ran the CLI on origin/main and on this draft branch so maintainers can compare the before/after output below. More context for each change is in the individual commits.

<details>
<summary>Before: Vite Doctor on origin/main (0 blockers, 4 errors, 33 warnings, 50 info)</summary>

```text
$ pnpm exec vite-doctor /tmp/nuxt-com-main-refresh.68ymqB --framework nuxt --no-cache

Detected: Nuxt 4.4.6 + Vue 3.5.34
Workspace: /tmp/nuxt-com-main-refresh.68ymqB
Health score: 28/100
Evidence used: manifest missing, route graph missing, build manifest missing, 0 prerender routes, 0 server routes
Confidence mix: 4 proven, 33 probable, 50 source-only

Errors
  [NUXT0060] useState() is serialized between server and client. Do not store functions, sockets, classes, Map/Set, or other non-serializable values.
  ├▶ fix: useState() is serialized between server and client. Do not store functions, sockets, classes, Map/Set, or other non-serializable values.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-state
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0060
    rule: nuxt/state/no-nonserializable-usestate
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useDateRange.ts:9:21
  [NUXT0020] useFetch() is called after await in Nuxt context and may lose async context.
  ├▶ fix: Call Nuxt composables before the first await or use Nuxt's compiler-aware data factories.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-nuxt-app
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0020
    rule: nuxt/context/no-composable-after-await
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useSponsors.ts:5:5
  [NUXT0020] useAsyncData() is called after await in Nuxt context and may lose async context.
  ├▶ fix: Call Nuxt composables before the first await or use Nuxt's compiler-aware data factories.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-nuxt-app
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0020
    rule: nuxt/context/no-composable-after-await
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useSponsors.ts:6:5
  [NUXT0009] Images need alt text or an explicit empty alt for decorative images.
  ├▶ fix: Add alt text that describes the image.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0009
    rule: nuxt-image/require-alt
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/deploy/index.vue:65:15

Warnings
  [VUE0022] Native buttons should declare type="button", type="submit", or type="reset".
  ├▶ fix: Add type="button" unless this button intentionally submits a form.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0022
    rule: vue/template/html-button-has-type
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/chat/ChatPanel.vue:126:13
  [VUE0020] This watcher reads DOM state before Vue has flushed owner DOM updates.
  ├▶ fix: Pass { flush: 'post' } or use watchPostEffect().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0020
    rule: vue/watch/require-post-flush-for-dom-read
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/AdminDashboard.vue:319:1
  [VUE0020] This watcher reads DOM state before Vue has flushed owner DOM updates.
  ├▶ fix: Pass { flush: 'post' } or use watchPostEffect().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0020
    rule: vue/watch/require-post-flush-for-dom-read
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/modules/index.vue:90:1
  [VUE0015] Vue 3.5 supports reactive props destructure with native default values.
  ├▶ fix: Use const { prop = defaultValue } = defineProps<Props>().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0015
    rule: vue/style/prefer-props-destructure-defaults
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/agent/AgentShader.vue:5:15
  [VUE0015] Vue 3.5 supports reactive props destructure with native default values.
  ├▶ fix: Use const { prop = defaultValue } = defineProps<Props>().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0015
    rule: vue/style/prefer-props-destructure-defaults
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/content/VideoAccordion.vue:2:1
  [VUE0015] Vue 3.5 supports reactive props destructure with native default values.
  ├▶ fix: Use const { prop = defaultValue } = defineProps<Props>().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0015
    rule: vue/style/prefer-props-destructure-defaults
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/EmptyCard.vue:2:1
  [VUE0015] Vue 3.5 supports reactive props destructure with native default values.
  ├▶ fix: Use const { prop = defaultValue } = defineProps<Props>().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0015
    rule: vue/style/prefer-props-destructure-defaults
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/feedback/FeedbackStatCard.vue:17:1
  [VUE0015] Vue 3.5 supports reactive props destructure with native default values.
  ├▶ fix: Use const { prop = defaultValue } = defineProps<Props>().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0015
    rule: vue/style/prefer-props-destructure-defaults
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/module/ModuleItem.vue:9:15
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/content/enterprise/support/EnterpriseSupportLogoCarousel.vue:11:19
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/content/ReadMore.vue:4:15
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/content/Sandbox.vue:15:15
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/module/ModuleProseA.vue:17:15
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/module/ModuleProseImg.vue:7:15
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/UInputCopy.vue:2:15
  [NITRO0011] $fetch() in Nitro handlers does not automatically carry request event context.
  ├▶ fix: Use event.$fetch() when proxying to other server routes.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NITRO0011
    rule: nitro/server/prefer-event-fetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/server/api/v1/teams/index.get.ts:5:5
  [NITRO0011] $fetch() in Nitro handlers does not automatically carry request event context.
  ├▶ fix: Use event.$fetch() when proxying to other server routes.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NITRO0011
    rule: nitro/server/prefer-event-fetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/server/api/v1/teams/index.get.ts:6:5
  [NITRO0011] $fetch() in Nitro handlers does not automatically carry request event context.
  ├▶ fix: Use event.$fetch() when proxying to other server routes.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NITRO0011
    rule: nitro/server/prefer-event-fetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/server/utils/team.ts:3:74
  [NITRO0008] Server handlers should read runtime config with the request event.
  ├▶ fix: Use useRuntimeConfig(event).
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NITRO0008
    rule: nitro/runtime/require-event-runtime-config-in-server
    source: /tmp/nuxt-com-main-refresh.68ymqB/server/utils/team.ts:20:15
  [NUXT0026] This fetch runs in setup for SSR-rendered data. Use useFetch() or useAsyncData() to avoid duplicate fetching and hydration issues.
  ├▶ fix: Replace with await useFetch(...) or await useAsyncData(key, () => $fetch(...)).
  ├▶ sources: https://nuxt.com/docs/4.x/getting-started/data-fetching
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0026
    rule: nuxt/fetch/no-raw-fetch-in-setup
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/PageHeaderLinks.vue:70:14
  [NUXT0026] This fetch runs in setup for SSR-rendered data. Use useFetch() or useAsyncData() to avoid duplicate fetching and hydration issues.
  ├▶ fix: Replace with await useFetch(...) or await useAsyncData(key, () => $fetch(...)).
  ├▶ sources: https://nuxt.com/docs/4.x/getting-started/data-fetching
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0026
    rule: nuxt/fetch/no-raw-fetch-in-setup
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/tools/FeedbackCard.vue:18:26
  [NUXT0039] `immediate: false` only disables initial execution. This async-data entry can still run from refreshNuxtData().
  ├▶ fix: Use async data for replay-safe reads, and keep one-shot actions outside Nuxt async-data entries.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0039
    rule: nuxt/no-manual-action-usefetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/AdminMcpInstall.vue:4:42
  [NUXT0039] `immediate: false` only disables initial execution. This async-data entry can still run from refreshNuxtData().
  ├▶ fix: Use async data for replay-safe reads, and keep one-shot actions outside Nuxt async-data entries.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0039
    rule: nuxt/no-manual-action-usefetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useEnterpriseAgencies.ts:6:39
  [NUXT0039] `immediate: false` only disables initial execution. This async-data entry can still run from refreshNuxtData().
  ├▶ fix: Use async data for replay-safe reads, and keep one-shot actions outside Nuxt async-data entries.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0039
    rule: nuxt/no-manual-action-usefetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useEnterpriseJobs.ts:7:35
  [NUXT0039] `immediate: false` only disables initial execution. This async-data entry can still run from refreshNuxtData().
  ├▶ fix: Use async data for replay-safe reads, and keep one-shot actions outside Nuxt async-data entries.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0039
    rule: nuxt/no-manual-action-usefetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useHostingProviders.ts:2:40
  [NUXT0039] `immediate: false` only disables initial execution. This async-data entry can still run from refreshNuxtData().
  ├▶ fix: Use async data for replay-safe reads, and keep one-shot actions outside Nuxt async-data entries.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0039
    rule: nuxt/no-manual-action-usefetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useModules.ts:45:29
  [NUXT0028] This keyed composable relies on a generated location key.
  ├▶ fix: Pass an explicit stable key before the data handler when data may be shared, prerendered, or wrapped.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-async-data
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0028
    rule: nuxt/fetch/require-stable-asyncdata-key
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useHostingProviders.ts:2:40
  [NUXT0023] SSR $fetch() to an internal API route may omit request cookies and auth headers.
  ├▶ fix: Use useFetch(), useRequestFetch(), or forward selected headers explicitly.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-request-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0023
    rule: nuxt/fetch/forward-auth-headers-ssr
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/tools/FeedbackCard.vue:18:26
  [NUXT0023] SSR $fetch() to an internal API route may omit request cookies and auth headers.
  ├▶ fix: Use useFetch(), useRequestFetch(), or forward selected headers explicitly.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-request-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0023
    rule: nuxt/fetch/forward-auth-headers-ssr
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useAgentChat.ts:93:5
  [NUXT0023] SSR $fetch() to an internal API route may omit request cookies and auth headers.
  ├▶ fix: Use useFetch(), useRequestFetch(), or forward selected headers explicitly.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-request-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0023
    rule: nuxt/fetch/forward-auth-headers-ssr
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useFeedback.ts:239:13
  [NUXT0057] SEO metadata is safer and better typed through Nuxt SEO composables.
  ├▶ fix: Use useSeoMeta() for SEO metadata and useHeadSafe() for untrusted values.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-seo-meta
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0057
    rule: nuxt/seo/prefer-seo-composables
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/app.vue:18:1
  [NUXT0057] SEO metadata is safer and better typed through Nuxt SEO composables.
  ├▶ fix: Use useSeoMeta() for SEO metadata and useHeadSafe() for untrusted values.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-seo-meta
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0057
    rule: nuxt/seo/prefer-seo-composables
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/chat.vue:10:1
  [NUXT0056] Head values derived from route, content, or user data should be constrained.
  ├▶ fix: Use useHeadSafe() or sanitize the value before passing it to useHead().
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-head-safe
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0056
    rule: nuxt/security/prefer-useheadsafe-for-untrusted-values
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useCanonical.ts:13:3
  [NUXT0008] Nuxt images should declare dimensions or responsive sizes.
  ├▶ fix: Add width/height for fixed images or sizes for responsive images.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0008
    rule: nuxt-image/prefer-responsive-dimensions
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/video-courses.vue:43:13

Info
  [VUE0023] Use Vue's same-name prop shorthand for message.
  ├▶ fix: Use :message.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/chat/ChatPanel.vue:162:30
  [VUE0023] Use Vue's same-name prop shorthand for message.
  ├▶ fix: Use :message.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/chat/ChatPanel.vue:168:19
  [VUE0023] Use Vue's same-name prop shorthand for open.
  ├▶ fix: Use :open.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/header/Header.vue:96:9
  [VUE0023] Use Vue's same-name prop shorthand for href.
  ├▶ fix: Use :href.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/module/ModuleProseA.vue:3:5
  [VUE0023] Use Vue's same-name prop shorthand for target.
  ├▶ fix: Use :target.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/module/ModuleProseA.vue:4:5
  [VUE0023] Use Vue's same-name prop shorthand for src.
  ├▶ fix: Use :src.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/module/ModuleProseImg.vue:34:5
  [VUE0023] Use Vue's same-name prop shorthand for alt.
  ├▶ fix: Use :alt.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/module/ModuleProseImg.vue:35:5
  [VUE0023] Use Vue's same-name prop shorthand for width.
  ├▶ fix: Use :width.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/module/ModuleProseImg.vue:36:5
  [VUE0023] Use Vue's same-name prop shorthand for height.
  ├▶ fix: Use :height.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/module/ModuleProseImg.vue:37:5
  [VUE0023] Use Vue's same-name prop shorthand for items.
  ├▶ fix: Use :items.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/PageHeaderLinks.vue:90:7
  [VUE0023] Use Vue's same-name prop shorthand for items.
  ├▶ fix: Use :items.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/VersionMenu.vue:11:5
  [VUE0023] Use Vue's same-name prop shorthand for title.
  ├▶ fix: Use :title.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/enterprise/jobs.vue:35:7
  [VUE0023] Use Vue's same-name prop shorthand for description.
  ├▶ fix: Use :description.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/enterprise/jobs.vue:36:7
  [VUE0023] Use Vue's same-name prop shorthand for title.
  ├▶ fix: Use :title.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/enterprise/sponsors.vue:36:7
  [VUE0023] Use Vue's same-name prop shorthand for description.
  ├▶ fix: Use :description.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/enterprise/sponsors.vue:37:7
  [VUE0023] Use Vue's same-name prop shorthand for key.
  ├▶ fix: Use :key.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/enterprise/sponsors.vue:43:65
  [VUE0023] Use Vue's same-name prop shorthand for logo.
  ├▶ fix: Use :logo.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/enterprise/support.vue:56:45
  [VUE0023] Use Vue's same-name prop shorthand for title.
  ├▶ fix: Use :title.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/newsletter.vue:30:7
  [VUE0023] Use Vue's same-name prop shorthand for description.
  ├▶ fix: Use :description.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/newsletter.vue:31:7
  [VUE0023] Use Vue's same-name prop shorthand for title.
  ├▶ fix: Use :title.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/templates.vue:38:7
  [VUE0023] Use Vue's same-name prop shorthand for description.
  ├▶ fix: Use :description.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/templates.vue:39:7
  [VUE0023] Use Vue's same-name prop shorthand for template.
  ├▶ fix: Use :template.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/templates.vue:52:15
  [VUE0023] Use Vue's same-name prop shorthand for index.
  ├▶ fix: Use :index.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/templates.vue:53:15
  [VUE0023] Use Vue's same-name prop shorthand for title.
  ├▶ fix: Use :title.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/video-courses.vue:35:7
  [VUE0023] Use Vue's same-name prop shorthand for description.
  ├▶ fix: Use :description.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/video-courses.vue:36:7
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useBlog.ts:4:39
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useDocsVersion.ts:54:26
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useEnterpriseAgencies.ts:6:39
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useEnterpriseJobs.ts:7:35
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useHostingProviders.ts:2:40
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useModules.ts:45:29
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useSponsors.ts:5:5
  [NUXT0013] Native <button> reimplements behavior that Nuxt UI already provides.
  ├▶ fix: Use <UButton> and map styling to Nuxt UI props such as icon, size, color, and variant.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0013
    rule: nuxt-ui/prefer-u-button
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/chat/ChatPanel.vue:126:13
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/ads/AdsMN.vue:12:3
  [NUXT0068] setInterval is easier to clean up through a composable.
  ├▶ fix: Use VueUse useIntervalFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/ads/AdsMN.vue:28:14
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/ads/AdsNuxtCertificate.vue:12:3
  [NUXT0068] setInterval is easier to clean up through a composable.
  ├▶ fix: Use VueUse useIntervalFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/ads/AdsNuxtCertificate.vue:28:14
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/agent/AgentFloatingInput.vue:26:17
  [NUXT0068] requestAnimationFrame is easier to clean up through a composable.
  ├▶ fix: Use VueUse useRafFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/agent/AgentIndicator.vue:63:7
  [NUXT0068] setInterval is easier to clean up through a composable.
  ├▶ fix: Use VueUse useIntervalFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/agent/AgentIndicator.vue:77:20
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/home/HomeSectionContributors.vue:36:20
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/composables/useFeedback.ts:244:36
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/layouts/default.vue:9:3
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/docs/[...slug].vue:49:5
  [NUXT0068] requestAnimationFrame is easier to clean up through a composable.
  ├▶ fix: Use VueUse useRafFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/docs/[...slug].vue:50:5
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/modules/index.vue:74:3
  [NUXT0006] Raw <img> misses Nuxt Image optimization and responsive providers.
  ├▶ fix: Use <NuxtImg> for application images.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0006
    rule: nuxt-image/prefer-nuxtimg
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/ads/AdsFreeWeekend.vue:9:7
  [NUXT0006] Raw <img> misses Nuxt Image optimization and responsive providers.
  ├▶ fix: Use <NuxtImg> for application images.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0006
    rule: nuxt-image/prefer-nuxtimg
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/components/module/ModuleProseImg.vue:33:3
  [NUXT0007] Format negotiation is clearer with <NuxtPicture>.
  ├▶ fix: Use <NuxtPicture> when serving modern formats with fallbacks.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0007
    rule: nuxt-image/prefer-nuxtpicture-for-formats
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/showcase.vue:116:15
  [NUXT0007] Format negotiation is clearer with <NuxtPicture>.
  ├▶ fix: Use <NuxtPicture> when serving modern formats with fallbacks.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0007
    rule: nuxt-image/prefer-nuxtpicture-for-formats
    source: /tmp/nuxt-com-main-refresh.68ymqB/app/pages/video-courses.vue:43:13

Summary
  0 blockers, 4 errors, 33 warnings, 50 info
  0 safe fixes available

Graph
  341 files, 596 imports, 241 exports, 309 roots, 0 cycles
```

</details>

<details>
<summary>After: Vite Doctor on this draft branch (0 blockers, 0 errors, 24 warnings, 50 info)</summary>

```text
$ pnpm exec vite-doctor /tmp/nuxt-com-browser-test.ujXeyY --framework nuxt --no-cache

Detected: Nuxt 4.4.6 + Vue 3.5.34
Workspace: /tmp/nuxt-com-browser-test.ujXeyY
Health score: 65/100
Evidence used: manifest missing, route graph missing, build manifest missing, 0 prerender routes, 0 server routes
Confidence mix: 0 proven, 24 probable, 50 source-only

Warnings
  [VUE0015] Vue 3.5 supports reactive props destructure with native default values.
  ├▶ fix: Use const { prop = defaultValue } = defineProps<Props>().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0015
    rule: vue/style/prefer-props-destructure-defaults
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/agent/AgentShader.vue:5:15
  [VUE0015] Vue 3.5 supports reactive props destructure with native default values.
  ├▶ fix: Use const { prop = defaultValue } = defineProps<Props>().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0015
    rule: vue/style/prefer-props-destructure-defaults
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/content/VideoAccordion.vue:2:1
  [VUE0015] Vue 3.5 supports reactive props destructure with native default values.
  ├▶ fix: Use const { prop = defaultValue } = defineProps<Props>().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0015
    rule: vue/style/prefer-props-destructure-defaults
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/EmptyCard.vue:2:1
  [VUE0015] Vue 3.5 supports reactive props destructure with native default values.
  ├▶ fix: Use const { prop = defaultValue } = defineProps<Props>().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0015
    rule: vue/style/prefer-props-destructure-defaults
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/feedback/FeedbackStatCard.vue:17:1
  [VUE0015] Vue 3.5 supports reactive props destructure with native default values.
  ├▶ fix: Use const { prop = defaultValue } = defineProps<Props>().
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0015
    rule: vue/style/prefer-props-destructure-defaults
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/module/ModuleItem.vue:9:15
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/content/enterprise/support/EnterpriseSupportLogoCarousel.vue:11:19
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/content/ReadMore.vue:4:15
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/content/Sandbox.vue:15:15
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/module/ModuleProseA.vue:17:15
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/module/ModuleProseImg.vue:7:15
  [VUE0016] TypeScript <script setup> components should declare props with a type argument.
  ├▶ fix: Use defineProps<Props>() instead of a runtime props declaration.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0016
    rule: vue/style/prefer-type-props
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/UInputCopy.vue:2:15
  [NUXT0026] This fetch runs in setup for SSR-rendered data. Use useFetch() or useAsyncData() to avoid duplicate fetching and hydration issues.
  ├▶ fix: Replace with await useFetch(...) or await useAsyncData(key, () => $fetch(...)).
  ├▶ sources: https://nuxt.com/docs/4.x/getting-started/data-fetching
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0026
    rule: nuxt/fetch/no-raw-fetch-in-setup
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/PageHeaderLinks.vue:70:14
  [NUXT0026] This fetch runs in setup for SSR-rendered data. Use useFetch() or useAsyncData() to avoid duplicate fetching and hydration issues.
  ├▶ fix: Replace with await useFetch(...) or await useAsyncData(key, () => $fetch(...)).
  ├▶ sources: https://nuxt.com/docs/4.x/getting-started/data-fetching
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0026
    rule: nuxt/fetch/no-raw-fetch-in-setup
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/tools/FeedbackCard.vue:18:26
  [NUXT0039] `immediate: false` only disables initial execution. This async-data entry can still run from refreshNuxtData().
  ├▶ fix: Use async data for replay-safe reads, and keep one-shot actions outside Nuxt async-data entries.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0039
    rule: nuxt/no-manual-action-usefetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/AdminMcpInstall.vue:4:42
  [NUXT0039] `immediate: false` only disables initial execution. This async-data entry can still run from refreshNuxtData().
  ├▶ fix: Use async data for replay-safe reads, and keep one-shot actions outside Nuxt async-data entries.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0039
    rule: nuxt/no-manual-action-usefetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useEnterpriseAgencies.ts:6:39
  [NUXT0039] `immediate: false` only disables initial execution. This async-data entry can still run from refreshNuxtData().
  ├▶ fix: Use async data for replay-safe reads, and keep one-shot actions outside Nuxt async-data entries.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0039
    rule: nuxt/no-manual-action-usefetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useEnterpriseJobs.ts:7:35
  [NUXT0039] `immediate: false` only disables initial execution. This async-data entry can still run from refreshNuxtData().
  ├▶ fix: Use async data for replay-safe reads, and keep one-shot actions outside Nuxt async-data entries.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0039
    rule: nuxt/no-manual-action-usefetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useHostingProviders.ts:2:40
  [NUXT0039] `immediate: false` only disables initial execution. This async-data entry can still run from refreshNuxtData().
  ├▶ fix: Use async data for replay-safe reads, and keep one-shot actions outside Nuxt async-data entries.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0039
    rule: nuxt/no-manual-action-usefetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useModules.ts:45:29
  [NUXT0028] This keyed composable relies on a generated location key.
  ├▶ fix: Pass an explicit stable key before the data handler when data may be shared, prerendered, or wrapped.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-async-data
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0028
    rule: nuxt/fetch/require-stable-asyncdata-key
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useHostingProviders.ts:2:40
  [NUXT0023] SSR $fetch() to an internal API route may omit request cookies and auth headers.
  ├▶ fix: Use useFetch(), useRequestFetch(), or forward selected headers explicitly.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-request-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0023
    rule: nuxt/fetch/forward-auth-headers-ssr
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/tools/FeedbackCard.vue:18:26
  [NUXT0023] SSR $fetch() to an internal API route may omit request cookies and auth headers.
  ├▶ fix: Use useFetch(), useRequestFetch(), or forward selected headers explicitly.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-request-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0023
    rule: nuxt/fetch/forward-auth-headers-ssr
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useAgentChat.ts:93:5
  [NUXT0023] SSR $fetch() to an internal API route may omit request cookies and auth headers.
  ├▶ fix: Use useFetch(), useRequestFetch(), or forward selected headers explicitly.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-request-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0023
    rule: nuxt/fetch/forward-auth-headers-ssr
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useFeedback.ts:239:13
  [NUXT0057] SEO metadata is safer and better typed through Nuxt SEO composables.
  ├▶ fix: Use useSeoMeta() for SEO metadata and useHeadSafe() for untrusted values.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-seo-meta
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0057
    rule: nuxt/seo/prefer-seo-composables
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/app.vue:18:1
  [NUXT0057] SEO metadata is safer and better typed through Nuxt SEO composables.
  ├▶ fix: Use useSeoMeta() for SEO metadata and useHeadSafe() for untrusted values.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/use-seo-meta
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0057
    rule: nuxt/seo/prefer-seo-composables
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/chat.vue:10:1

Info
  [VUE0023] Use Vue's same-name prop shorthand for message.
  ├▶ fix: Use :message.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/chat/ChatPanel.vue:163:30
  [VUE0023] Use Vue's same-name prop shorthand for message.
  ├▶ fix: Use :message.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/chat/ChatPanel.vue:169:19
  [VUE0023] Use Vue's same-name prop shorthand for open.
  ├▶ fix: Use :open.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/header/Header.vue:96:9
  [VUE0023] Use Vue's same-name prop shorthand for href.
  ├▶ fix: Use :href.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/module/ModuleProseA.vue:3:5
  [VUE0023] Use Vue's same-name prop shorthand for target.
  ├▶ fix: Use :target.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/module/ModuleProseA.vue:4:5
  [VUE0023] Use Vue's same-name prop shorthand for src.
  ├▶ fix: Use :src.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/module/ModuleProseImg.vue:34:5
  [VUE0023] Use Vue's same-name prop shorthand for alt.
  ├▶ fix: Use :alt.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/module/ModuleProseImg.vue:35:5
  [VUE0023] Use Vue's same-name prop shorthand for width.
  ├▶ fix: Use :width.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/module/ModuleProseImg.vue:36:5
  [VUE0023] Use Vue's same-name prop shorthand for height.
  ├▶ fix: Use :height.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/module/ModuleProseImg.vue:37:5
  [VUE0023] Use Vue's same-name prop shorthand for items.
  ├▶ fix: Use :items.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/PageHeaderLinks.vue:90:7
  [VUE0023] Use Vue's same-name prop shorthand for items.
  ├▶ fix: Use :items.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/VersionMenu.vue:11:5
  [VUE0023] Use Vue's same-name prop shorthand for title.
  ├▶ fix: Use :title.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/enterprise/jobs.vue:35:7
  [VUE0023] Use Vue's same-name prop shorthand for description.
  ├▶ fix: Use :description.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/enterprise/jobs.vue:36:7
  [VUE0023] Use Vue's same-name prop shorthand for title.
  ├▶ fix: Use :title.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/enterprise/sponsors.vue:36:7
  [VUE0023] Use Vue's same-name prop shorthand for description.
  ├▶ fix: Use :description.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/enterprise/sponsors.vue:37:7
  [VUE0023] Use Vue's same-name prop shorthand for key.
  ├▶ fix: Use :key.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/enterprise/sponsors.vue:43:65
  [VUE0023] Use Vue's same-name prop shorthand for logo.
  ├▶ fix: Use :logo.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/enterprise/support.vue:56:45
  [VUE0023] Use Vue's same-name prop shorthand for title.
  ├▶ fix: Use :title.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/newsletter.vue:30:7
  [VUE0023] Use Vue's same-name prop shorthand for description.
  ├▶ fix: Use :description.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/newsletter.vue:31:7
  [VUE0023] Use Vue's same-name prop shorthand for title.
  ├▶ fix: Use :title.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/templates.vue:38:7
  [VUE0023] Use Vue's same-name prop shorthand for description.
  ├▶ fix: Use :description.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/templates.vue:39:7
  [VUE0023] Use Vue's same-name prop shorthand for template.
  ├▶ fix: Use :template.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/templates.vue:52:15
  [VUE0023] Use Vue's same-name prop shorthand for index.
  ├▶ fix: Use :index.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/templates.vue:53:15
  [VUE0023] Use Vue's same-name prop shorthand for title.
  ├▶ fix: Use :title.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/video-courses.vue:35:7
  [VUE0023] Use Vue's same-name prop shorthand for description.
  ├▶ fix: Use :description.
  ├▶ sources: https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/VUE0023
    rule: vue/template/prefer-same-name-prop-shorthand
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/video-courses.vue:36:7
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useBlog.ts:4:39
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useDocsVersion.ts:54:26
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useEnterpriseAgencies.ts:6:39
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useEnterpriseJobs.ts:7:35
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useHostingProviders.ts:2:40
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useModules.ts:45:29
  [NUXT0027] Exported custom data composables should use Nuxt's compiler-aware data factories.
  ├▶ fix: Use createUseFetch() or createUseAsyncData() for reusable keyed data composables.
  ├▶ sources: https://nuxt.com/docs/4.x/api/composables/create-use-fetch
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0027
    rule: nuxt/fetch/prefer-create-use-fetch
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useSponsors.ts:4:33
  [NUXT0013] Native <button> reimplements behavior that Nuxt UI already provides.
  ├▶ fix: Use <UButton> and map styling to Nuxt UI props such as icon, size, color, and variant.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0013
    rule: nuxt-ui/prefer-u-button
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/chat/ChatPanel.vue:126:13
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/ads/AdsMN.vue:12:3
  [NUXT0068] setInterval is easier to clean up through a composable.
  ├▶ fix: Use VueUse useIntervalFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/ads/AdsMN.vue:28:14
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/ads/AdsNuxtCertificate.vue:12:3
  [NUXT0068] setInterval is easier to clean up through a composable.
  ├▶ fix: Use VueUse useIntervalFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/ads/AdsNuxtCertificate.vue:28:14
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/agent/AgentFloatingInput.vue:26:17
  [NUXT0068] requestAnimationFrame is easier to clean up through a composable.
  ├▶ fix: Use VueUse useRafFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/agent/AgentIndicator.vue:63:7
  [NUXT0068] setInterval is easier to clean up through a composable.
  ├▶ fix: Use VueUse useIntervalFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/agent/AgentIndicator.vue:77:20
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/home/HomeSectionContributors.vue:36:20
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/composables/useFeedback.ts:244:36
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/layouts/default.vue:9:3
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/docs/[...slug].vue:49:5
  [NUXT0068] requestAnimationFrame is easier to clean up through a composable.
  ├▶ fix: Use VueUse useRafFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/docs/[...slug].vue:50:5
  [NUXT0068] setTimeout is easier to clean up through a composable.
  ├▶ fix: Use VueUse useTimeoutFn() for lifecycle-aware timing.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0068
    rule: vueuse/prefer-use-timers
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/modules/index.vue:74:3
  [NUXT0006] Raw <img> misses Nuxt Image optimization and responsive providers.
  ├▶ fix: Use <NuxtImg> for application images.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0006
    rule: nuxt-image/prefer-nuxtimg
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/ads/AdsFreeWeekend.vue:9:7
  [NUXT0006] Raw <img> misses Nuxt Image optimization and responsive providers.
  ├▶ fix: Use <NuxtImg> for application images.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0006
    rule: nuxt-image/prefer-nuxtimg
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/components/module/ModuleProseImg.vue:33:3
  [NUXT0007] Format negotiation is clearer with <NuxtPicture>.
  ├▶ fix: Use <NuxtPicture> when serving modern formats with fallbacks.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0007
    rule: nuxt-image/prefer-nuxtpicture-for-formats
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/showcase.vue:116:15
  [NUXT0007] Format negotiation is clearer with <NuxtPicture>.
  ├▶ fix: Use <NuxtPicture> when serving modern formats with fallbacks.
  ╰▶ see: https://vite-doctor.onmax.me/diagnostics/NUXT0007
    rule: nuxt-image/prefer-nuxtpicture-for-formats
    source: /tmp/nuxt-com-browser-test.ujXeyY/app/pages/video-courses.vue:43:13

Summary
  0 blockers, 0 errors, 24 warnings, 50 info
  0 safe fixes available

Graph
  341 files, 597 imports, 241 exports, 331 roots, 0 cycles
```

</details>

_PR made with codex_
