### PR TITLE
ci: scope ci workflow token to contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an explicit least-privilege `permissions:` block to `.github/workflows/ci.yml`. The job only reads the repository, so `contents: read` is sufficient; today the workflow inherits whatever the repository default grants, which is broader than it needs. This is one of the checks OpenSSF Scorecard flags under [Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions).