### PR TITLE
feat(agent): refine tool display and model config

### DIFF
--- a/app/components/agent/AgentIndicator.vue
+++ b/app/components/agent/AgentIndicator.vue
@@ -89,7 +89,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="flex items-center text-xs text-muted overflow-hidden">
+  <div class="flex items-center text-sm text-muted overflow-hidden">
     <div
       class="shrink-0 mr-2 grid"
       :style="{
@@ -108,6 +108,6 @@ onUnmounted(() => {
       />
     </div>
 
-    <UChatShimmer :text="displayedText" class="font-mono tracking-tight" />
+    <UChatShimmer :text="displayedText" />
   </div>
 </template>

--- a/app/components/agent/AgentPanelMain.vue
+++ b/app/components/agent/AgentPanelMain.vue
@@ -26,7 +26,7 @@ const votes = defineModel<Map<string, boolean>>('votes', { required: true })
       :status="chat.status"
       compact
       class="px-0 gap-2"
-      :user="{ ui: { container: 'max-w-full' } }"
+      :user="{ ui: { container: 'max-w-full pb-3' } }"
     >
       <template #indicator>
         <AgentIndicator />

--- a/app/components/chat/ChatContent.vue
+++ b/app/components/chat/ChatContent.vue
@@ -49,6 +49,7 @@ function getMessagePagePath(message: UIMessage): string | null {
       :text="part.text"
       :streaming="isPartStreaming(part)"
       icon="i-lucide-brain"
+      chevron="leading"
     >
       <AgentComark
         :markdown="part.text"
@@ -59,6 +60,7 @@ function getMessagePagePath(message: UIMessage): string | null {
     <template v-else-if="isToolUIPart(part)">
       <UChatTool
         v-if="getToolName(part) === 'web_search'"
+        icon="i-lucide-search"
         :text="isToolStreaming(part) ? 'Searching the web...' : 'Searched the web'"
         :suffix="getSearchQuery(part)"
         :streaming="isToolStreaming(part)"
@@ -85,7 +87,7 @@ function getMessagePagePath(message: UIMessage): string | null {
         />
         <div
           v-if="part.state === 'output-available' && part.output && !(part.output as Record<string, unknown>).error && hasTemplatesOutput(part.output)"
-          class="grid grid-cols-1 sm:grid-cols-2 gap-3"
+          class="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full"
         >
           <ToolsTemplateCard
             v-for="tpl in getTemplates(part.output)"
@@ -142,9 +144,9 @@ function getMessagePagePath(message: UIMessage): string | null {
       <template v-else-if="(getToolName(part) === 'get-module' || getToolName(part) === 'list-modules') && getModuleCards(part).length">
         <UChatTool
           :text="getToolText(part)"
+          :suffix="getToolSuffix(part)"
           :icon="getToolIcon(part)"
           :streaming="isToolStreaming(part)"
-          chevron="leading"
         />
         <div class="flex flex-col gap-2">
           <ToolsModuleCard
@@ -157,11 +159,12 @@ function getMessagePagePath(message: UIMessage): string | null {
       <UChatTool
         v-else
         :text="getToolText(part)"
+        :suffix="getToolSuffix(part)"
         :icon="getToolIcon(part)"
         :streaming="isToolStreaming(part)"
         chevron="leading"
       >
-        <pre v-if="getToolOutput(part)" class="text-xs text-dimmed whitespace-pre-wrap break-all" v-text="getToolOutput(part)" />
+        <pre v-if="getToolOutput(part)" class="text-xs text-dimmed whitespace-pre-wrap break-all rounded-md border border-muted bg-muted p-2" v-text="getToolOutput(part)" />
       </UChatTool>
     </template>
 
@@ -172,9 +175,9 @@ function getMessagePagePath(message: UIMessage): string | null {
         :streaming="isPartStreaming(part)"
       />
       <div v-else-if="message.role === 'user'">
-        <div v-if="getMessagePagePath(message)" class="flex items-center gap-1.5 mb-1.5 rounded-md bg-default/10 px-2 py-1 w-fit">
+        <div v-if="getMessagePagePath(message)" class="flex items-center gap-1 w-fit my-1">
           <img src="/icon.png" alt="Nuxt" class="size-3.5 shrink-0">
-          <span class="text-xs text-default/70">{{ getMessagePagePath(message)!.replace(/^\//, '') }}</span>
+          <span class="text-xs text-muted">{{ getMessagePagePath(message)!.replace(/^\//, '') }}</span>
         </div>
         <p class="whitespace-pre-wrap text-sm/6">
           {{ part.text }}

--- a/app/composables/useChatTools.ts
+++ b/app/composables/useChatTools.ts
@@ -69,29 +69,48 @@ export interface PlaygroundCardData {
   dir?: string
 }
 
-function getToolMessage(state: ToolState, toolName: string, toolInput: Record<string, string | undefined>) {
+function getToolMessage(state: ToolState, toolName: string) {
   const searchVerb = state === 'output-available' ? 'Searched' : 'Searching'
   const readVerb = state === 'output-available' ? 'Read' : 'Reading'
   const foundVerb = state === 'output-available' ? 'Found' : 'Finding'
 
   return {
-    'list-documentation-pages': `${searchVerb} documentation${toolInput.search ? ` · ${toolInput.search}` : ''}`,
-    'get-documentation-page': `${readVerb} ${toolInput.path || '...'}`,
+    'list-documentation-pages': `${searchVerb} documentation`,
+    'get-documentation-page': `${readVerb} documentation`,
     'get-getting-started-guide': `${readVerb} getting started`,
-    'get-blog-post': `${readVerb} ${toolInput.path || 'blog post'}`,
-    'get-deploy-provider': `${readVerb} ${toolInput.path || 'deploy guide'}`,
-    'get-changelog': `${searchVerb} changelog${toolInput.repo ? ` · ${toolInput.repo}` : ''}`,
-    'list-modules': `${searchVerb} modules${toolInput.search ? ` · ${toolInput.search}` : ''}`,
-    'get-module': `${readVerb} module ${toolInput.slug || '...'}`,
+    'list-blog-posts': `${searchVerb} blog posts`,
+    'get-blog-post': `${readVerb} blog post`,
+    'list-deploy-providers': `${searchVerb} deploy providers`,
+    'get-deploy-provider': `${readVerb} deploy guide`,
+    'get-changelog': `${searchVerb} changelog`,
+    'list-modules': `${searchVerb} modules`,
+    'get-module': `${readVerb} module`,
     'show_template': `${foundVerb} templates`,
     'show_blog_post': `${foundVerb} blog post`,
     'show_hosting': `${foundVerb} hosting provider`,
-    'open_playground': `${state === 'output-available' ? 'Generated' : 'Generating'} playground`
+    'open_playground': `${state === 'output-available' ? 'Generated' : 'Generating'} playground`,
+    'search_github_issues': `${searchVerb} issues`
   }[toolName] || `${searchVerb} ${toolName}`
 }
 
 export function getToolText(part: ToolPart) {
-  return getToolMessage(part.state, getToolName(part), (part.input || {}) as Record<string, string | undefined>)
+  return getToolMessage(part.state, getToolName(part))
+}
+
+export function getToolSuffix(part: ToolPart): string | undefined {
+  const toolName = getToolName(part)
+  const toolInput = (part.input || {}) as Record<string, string | undefined>
+
+  return {
+    'list-documentation-pages': toolInput.search,
+    'get-documentation-page': toolInput.path,
+    'get-blog-post': toolInput.path,
+    'get-deploy-provider': toolInput.path,
+    'get-changelog': toolInput.repo,
+    'list-modules': toolInput.search,
+    'get-module': toolInput.slug,
+    'search_github_issues': toolInput.query
+  }[toolName] || undefined
 }
 
 export function getToolIcon(part: ToolPart): string {
@@ -101,7 +120,9 @@ export function getToolIcon(part: ToolPart): string {
     'list-documentation-pages': 'i-lucide-book-open',
     'get-documentation-page': 'i-lucide-file-text',
     'get-getting-started-guide': 'i-lucide-rocket',
+    'list-blog-posts': 'i-lucide-newspaper',
     'get-blog-post': 'i-lucide-newspaper',
+    'list-deploy-providers': 'i-lucide-cloud',
     'get-deploy-provider': 'i-lucide-cloud',
     'get-changelog': 'i-lucide-history',
     'list-modules': 'i-lucide-box',
@@ -109,7 +130,8 @@ export function getToolIcon(part: ToolPart): string {
     'show_template': 'i-lucide-layout-template',
     'show_blog_post': 'i-lucide-newspaper',
     'show_hosting': 'i-lucide-server',
-    'open_playground': 'i-simple-icons-stackblitz'
+    'open_playground': 'i-simple-icons-stackblitz',
+    'search_github_issues': 'i-lucide-github'
   }[toolName] || 'i-lucide-search'
 }
 

--- a/app/utils/ai.ts
+++ b/app/utils/ai.ts
@@ -9,8 +9,6 @@ export function getMergedParts(parts: UIMessage['parts']): UIMessage['parts'] {
     if (part.type === 'source-url') {
       if (prev && isTextUIPart(prev)) {
         result[result.length - 1] = { type: 'text', text: prev.text + sourceToInlineMdc(part.url) }
-      } else {
-        result.push({ type: 'text', text: sourceToInlineMdc(part.url) })
       }
       continue
     }

--- a/server/api/agent.post.ts
+++ b/server/api/agent.post.ts
@@ -1,6 +1,7 @@
-import { streamText, convertToModelMessages, createUIMessageStream, createUIMessageStreamResponse, safeValidateUIMessages } from 'ai'
+import { streamText, convertToModelMessages, createUIMessageStream, createUIMessageStreamResponse, safeValidateUIMessages, stepCountIs, smoothStream } from 'ai'
 import type { ToolSet, UIMessage } from 'ai'
 import { createMCPClient } from '@ai-sdk/mcp'
+import type { AnthropicLanguageModelOptions } from '@ai-sdk/anthropic'
 import { anthropic } from '@ai-sdk/anthropic'
 import { createAILogger, createEvlogIntegration } from 'evlog/ai'
 import { sql } from 'drizzle-orm'
@@ -16,18 +17,6 @@ import { reportIssueTool } from '../utils/tools/report-issue'
 const MCP_PATH = '/mcp'
 const MODEL = 'anthropic/claude-sonnet-4.6'
 const MAX_STEPS = 10
-
-function stopWhenResponseComplete({ steps }: { steps: { text?: string, toolCalls?: unknown[] }[] }): boolean {
-  const lastStep = steps.at(-1)
-  if (!lastStep) return false
-
-  const hasText = Boolean(lastStep.text && lastStep.text.trim().length > 0)
-  const hasNoToolCalls = !lastStep.toolCalls || lastStep.toolCalls.length === 0
-
-  if (hasText && hasNoToolCalls) return true
-
-  return steps.length >= MAX_STEPS
-}
 
 const baseSystemPrompt = `You are **the Nuxt Agent**, Nuxt's documentation agent on nuxt.com. You help users navigate the official documentation, blog, modules catalog, and guides.
 
@@ -177,10 +166,21 @@ export default defineEventHandler(async (event) => {
     execute: async ({ writer }) => {
       const result = streamText({
         model: ai.wrap(MODEL),
-        maxOutputTokens: 4000,
+        maxOutputTokens: 8000,
         maxRetries: 2,
         abortSignal: abortController.signal,
-        stopWhen: stopWhenResponseComplete,
+        stopWhen: stepCountIs(MAX_STEPS),
+        providerOptions: {
+          anthropic: {
+            thinking: {
+              type: 'adaptive'
+            },
+            effort: 'low'
+          } satisfies AnthropicLanguageModelOptions,
+          gateway: {
+            caching: 'auto'
+          }
+        },
         system: buildSystemPrompt(pagePath),
         messages: await convertToModelMessages(messages),
         tools: {
@@ -198,6 +198,7 @@ export default defineEventHandler(async (event) => {
           isEnabled: true,
           integrations: [createEvlogIntegration(ai)]
         },
+        experimental_transform: smoothStream(),
         onFinish: () => {
           closeMcp()
         },


### PR DESCRIPTION
## Summary

Improvements to the Nuxt Agent's tool rendering and backend model configuration.

### Tool display (`useChatTools.ts`, `ChatContent.vue`)
- Split the tool label (`getToolText`) from the dynamic detail (`getToolSuffix`) so the verb stays stable while the query/path renders as a suffix.
- Added labels and icons for new tools: `list-blog-posts`, `list-deploy-providers`, and `search_github_issues`.
- Added a `i-lucide-search` icon to the web search tool, `chevron="leading"` on reasoning, and styled the tool output `pre` block.
- Restyled the user message page-path pill.

### Backend (`server/api/agent.post.ts`)
- Switched to Anthropic adaptive thinking (`effort: 'low'`) with gateway `caching: 'auto'`.
- Replaced the custom `stopWhenResponseComplete` with `stepCountIs(MAX_STEPS)` (the default streamText behavior already stops when the model finishes without tool calls).
- Bumped `maxOutputTokens` to 8000 to account for reasoning tokens.
- Added `smoothStream()` for smoother streaming output.

### Misc
- `ai.ts`: only inline `source-url` parts into adjacent assistant text (standalone sources are no longer pushed as their own text part).
- `AgentIndicator.vue`: minor sizing/font tweaks.

## Test plan
- [ ] Run the agent and confirm tool labels + suffixes render correctly across documentation, modules, blog, deploy, and github issue searches.
- [ ] Verify reasoning/thinking streams smoothly and responses stay within the new token budget.
- [ ] Confirm sources still render inline within assistant messages.