### PR TITLE
fix: twoslash popup rendering and styling

### DIFF
--- a/app/assets/css/twoslash.css
+++ b/app/assets/css/twoslash.css
@@ -6,7 +6,7 @@
   --vp-c-brand: var(--color-primary-500);
   --vp-font-family-base: inherit;
   --vp-font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  --vp-code-font-size: 1em;
+  --vp-code-font-size: 0.875rem;
   --vp-z-index-local-nav: 10;
 }
 
@@ -17,8 +17,31 @@ html:not(.dark) {
   --vp-c-border: var(--color-neutral-300);
 }
 
-.twoslash-popup-container .twoslash-popup-code {
-  font-size: 0.9em;
+/* Twoslash popups are rendered through MDC, so the `code`/`pre` nodes they embed
+   get mapped to Nuxt UI's Prose components (ProseCodeInline / ProsePre). That
+   wraps the popup content in a bordered, padded code block with a copy button.
+   Strip those styles so the popup just shows the plain highlighted code. */
+.twoslash-popup-container .twoslash-popup-code,
+.twoslash-popup-container .twoslash-popup-code pre,
+.twoslash-popup-container .twoslash-popup-code code {
+  display: block;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  color: inherit;
+  font-weight: inherit;
+  font-size: var(--vp-code-font-size);
+}
+
+/* Wrapper div added by ProsePre around the multi-line type popup */
+.twoslash-popup-container .twoslash-popup-code > div {
+  margin: 0;
+}
+
+/* Copy button injected by ProsePre */
+.twoslash-popup-container .twoslash-popup-code button {
+  display: none;
 }
 
 .twoslash-popup-container .twoslash-popup-code .line {
@@ -28,6 +51,19 @@ html:not(.dark) {
 .twoslash-popup-container .shiki .line {
   --shiki-default-bg: transparent;
   --shiki-dark-bg: transparent;
+}
+
+.twoslash-popup-docs p {
+  margin: 0;
+  line-height: calc(1.25 / 0.875);
+}
+
+/* Inline code inside the docs section also picks up ProseCodeInline styling */
+.twoslash-popup-docs code {
+  padding: 0;
+  border: 0;
+  color: inherit;
+  font-size: inherit;
 }
 
 .twoslash-floating .twoslash-popup-docs-tags .twoslash-popup-docs-tag-name {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -629,10 +629,10 @@ export default defineNuxtConfig({
   },
   twoslash: {
     floatingVueOptions: {
-      classMarkdown: 'prose prose-primary dark:prose-invert'
+      classMarkdown: ''
     },
-    // Skip Twoslash in dev to improve performance. Turn this on when you want to explicitly test twoslash in dev.
-    enableInDev: false,
+    // Skip Twoslash in dev to improve performance ($development overrides enableInDev).
+    enableInDev: true,
     // Do not throw when twoslash fails, the typecheck should be down in github.com/nuxt/nuxt's CI
     throws: false
   }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -632,7 +632,7 @@ export default defineNuxtConfig({
       classMarkdown: ''
     },
     // Skip Twoslash in dev to improve performance ($development overrides enableInDev).
-    enableInDev: true,
+    enableInDev: false,
     // Do not throw when twoslash fails, the typecheck should be down in github.com/nuxt/nuxt's CI
     throws: false
   }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -628,10 +628,7 @@ export default defineNuxtConfig({
     siteKey: '0x4AAAAAAAP2vNBsTBT3ucZi'
   },
   twoslash: {
-    floatingVueOptions: {
-      classMarkdown: ''
-    },
-    // Skip Twoslash in dev to improve performance ($development overrides enableInDev).
+    // Skip Twoslash in dev to improve performance. Turn this on when you want to explicitly test twoslash in dev.
     enableInDev: false,
     // Do not throw when twoslash fails, the typecheck should be down in github.com/nuxt/nuxt's CI
     throws: false

--- a/patches/nuxt-content-twoslash@0.4.0.patch
+++ b/patches/nuxt-content-twoslash@0.4.0.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/runtime/transformer.js b/dist/runtime/transformer.js
+index c229c05c309a081b29af9c547f1207018f193a80..b88e831a3c2eb93341eab4dc5bb0f2d6dd88dbda 100644
+--- a/dist/runtime/transformer.js
++++ b/dist/runtime/transformer.js
+@@ -32,6 +32,10 @@ export async function createTransformer(
+   extraOptions,
+ ) {
+   const prepend = [
++    // `nuxt.d.ts` (app context) no longer references the `nuxt` package types since
++    // Nuxt's type-context split, so config-level globals like `defineNuxtConfig` are
++    // not resolvable here. Reference them explicitly so untagged config snippets work.
++    `/// <reference types="nuxt" />`,
+     `/// <reference path="${join(rootDir, '.nuxt/nuxt.d.ts')}" />`,
+     '',
+   ].join('\n')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  nuxt-content-twoslash@0.4.0: ff6548624c0498609b36b4649a9e2d9fc509d2b29e55b73588af9e1195e7550d
+
 importers:
 
   .:
@@ -212,7 +215,7 @@ importers:
         version: 20.9.0
       nuxt-content-twoslash:
         specifier: ^0.4.0
-        version: 0.4.0(@nuxtjs/mdc@0.22.0(magicast@0.5.3))(magicast@0.5.3)
+        version: 0.4.0(patch_hash=ff6548624c0498609b36b4649a9e2d9fc509d2b29e55b73588af9e1195e7550d)(@nuxtjs/mdc@0.22.0(magicast@0.5.3))(magicast@0.5.3)
       playwright:
         specifier: ^1.60.0
         version: 1.60.0
@@ -18064,7 +18067,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-content-twoslash@0.4.0(@nuxtjs/mdc@0.22.0(magicast@0.5.3))(magicast@0.5.3):
+  nuxt-content-twoslash@0.4.0(patch_hash=ff6548624c0498609b36b4649a9e2d9fc509d2b29e55b73588af9e1195e7550d)(@nuxtjs/mdc@0.22.0(magicast@0.5.3))(magicast@0.5.3):
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@nuxtjs/mdc': 0.22.0(magicast@0.5.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,3 +14,6 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - '@nuxt/ui@4.8.0'
+
+patchedDependencies:
+  nuxt-content-twoslash@0.4.0: patches/nuxt-content-twoslash@0.4.0.patch


### PR DESCRIPTION
## Summary

Twoslash popups are rendered through MDC, so the `code`/`pre` nodes they embed get mapped to Nuxt UI's Prose components (`ProseCodeInline` / `ProsePre`). That wrapped popups in bordered, padded code blocks with a copy button instead of plain highlighted code.

- Reset the inherited Prose styles within `.twoslash-popup-container` (margins, borders, padding, `bg-muted`, copy button) so popups show plain highlighted code, for both the inline and multi-line (`pre`) type cases as well as inline code in the docs section
- Add a patch for `nuxt-content-twoslash` so config-level globals like `defineNuxtConfig` resolve in untagged config snippets (Nuxt's type-context split means `nuxt.d.ts` no longer references the `nuxt` package types)

## Test plan

- [ ] Hover a type in a `twoslash` code block, confirm the popup shows plain highlighted code with no border, copy button, or extra padding
- [ ] Check both a single-line type popup and a multi-line type popup
- [ ] Check inline code inside a popup's docs section renders without the Nuxt UI inline-code chip styling