### PR TITLE
perf(prerender): isr for docs pages

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -158,7 +158,7 @@ export default defineNuxtConfig({
     // based on `Accept` and `User-Agent`, so cached responses must vary on both).
     // /raw/** is the rewrite destination — it must carry Vary too so CDNs
     // don't serve cached markdown to a browser that asked for HTML.
-    '/docs/**': { headers: { Vary: 'Accept, User-Agent' } },
+    '/docs/**': { isr: 60 * 60, prerender: false, headers: { Vary: 'Accept, User-Agent' } },
     '/blog/**': { headers: { Vary: 'Accept, User-Agent' } },
     '/deploy/**': { headers: { Vary: 'Accept, User-Agent' } },
     '/raw/**': { headers: { Vary: 'Accept, User-Agent' } },


### PR DESCRIPTION
## Summary
- Serve `/docs/**` via ISR instead of build-time prerender (intro pages stay prerendered via explicit route rules).

## Test plan
- [ ] Compare Vercel build duration vs main
- [ ] Verify docs pages render on first request after deploy