### PR TITLE
perf(prerender): stop prerendering raw markdown routes

### DIFF
--- a/app/pages/changelog.vue
+++ b/app/pages/changelog.vue
@@ -22,10 +22,6 @@ defineOgImage('Docs.takumi', {
   description
 })
 
-if (import.meta.server) {
-  prerenderRoutes(['/raw/changelog.md'])
-}
-
 const { data: releases } = await useFetch('/api/releases')
 const openStates = reactive<Record<string, boolean>>({})
 

--- a/app/pages/docs/[...slug].vue
+++ b/app/pages/docs/[...slug].vue
@@ -142,8 +142,6 @@ if (SUPPORTED_DOCS_PATH_REGEX.test(path.value)) {
 }
 
 if (import.meta.server) {
-  prerenderRoutes([joinURL('/raw', `${path.value}.md`)])
-
   useSchemaOrg([
     defineArticle({
       '@type': 'TechArticle',

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -42,8 +42,6 @@ useSeoMeta({
 useCanonical('/raw/index.md')
 
 if (import.meta.server) {
-  prerenderRoutes(['/raw/index.md'])
-
   useSeoMeta({
     ogTitle: title,
     ogDescription: description,

--- a/app/pages/modules/index.vue
+++ b/app/pages/modules/index.vue
@@ -36,8 +36,6 @@ useSeoMeta({
 useCanonical('/raw/modules.md')
 
 if (import.meta.server) {
-  prerenderRoutes(['/raw/modules.md'])
-
   const site = useSiteConfig()
   useSeoMeta({
     ogDescription: description,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -461,6 +461,7 @@ export default defineNuxtConfig({
       crawlLinks: true,
       ignore: [
         route => route === '/modules' || route.startsWith('/modules/'),
+        route => route.startsWith('/raw/'),
         route => route.startsWith('/admin'),
         route => route.startsWith('/login'),
         route => route.startsWith('/dashboard'),


### PR DESCRIPTION
## Summary
- Remove `prerenderRoutes('/raw/*.md')` calls that double the prerender queue for docs and landing pages.

## Test plan
- [ ] Compare Vercel build duration vs main
- [ ] Verify `/raw/docs/**` still works on first request (md-rewrite)