### PR TITLE
perf(prerender): skip stats fetch during prerender

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -359,7 +359,7 @@ onMounted(() => {
               </div>
               <div class="flex flex-col">
                 <span class="font-semibold text-lg text-highlighted">
-                  {{ formatNumber(stats.monthlyDownloads) }}
+                  {{ stats ? formatNumber(stats.monthlyDownloads) : '...' }}
                 </span>
                 <p class="text-sm">
                   Monthly downloads
@@ -375,7 +375,7 @@ onMounted(() => {
               </div>
               <div class="flex flex-col">
                 <span class="font-semibold text-lg text-highlighted">
-                  {{ formatNumber(stats.stars) }}
+                  {{ stats ? formatNumber(stats.stars) : '...' }}
                 </span>
                 <p class="text-sm">
                   GitHub Stars

--- a/app/pages/showcase.vue
+++ b/app/pages/showcase.vue
@@ -60,7 +60,7 @@ onMounted(() => {
               </div>
               <div class="flex flex-col items-center">
                 <h3 class="text-4xl font-bold">
-                  {{ formatNumber(stats.stars) }}
+                  {{ stats ? formatNumber(stats.stars) : '...' }}
                 </h3>
                 <p class="text-sm text-muted">
                   GitHub Stars
@@ -68,7 +68,7 @@ onMounted(() => {
               </div>
               <div class="flex flex-col items-center">
                 <h3 class="text-4xl font-bold">
-                  {{ formatNumber(stats.monthlyDownloads) }}
+                  {{ stats ? formatNumber(stats.monthlyDownloads) : '...' }}
                 </h3>
                 <p class="text-sm text-muted">
                   Monthly Downloads

--- a/app/plugins/stats.ts
+++ b/app/plugins/stats.ts
@@ -1,7 +1,7 @@
 export default defineNuxtPlugin(async () => {
   const stats = useStats()
 
-  if (import.meta.server) {
+  if (import.meta.server && !import.meta.prerender) {
     stats.value = await $fetch('/api/stats').catch(() => null)
   }
   onNuxtReady(async () => {


### PR DESCRIPTION
## Summary
- Avoid calling `/api/stats` on every prerendered page; load stats client-side after hydration instead.

## Test plan
- [ ] Compare Vercel build duration vs main
- [ ] Verify header stats appear after page load