### PR TITLE
perf(prerender): disable link crawler

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -461,6 +461,7 @@ export default defineNuxtConfig({
       crawlLinks: false,
       ignore: [
         route => route === '/modules' || route.startsWith('/modules/'),
+        route => route.startsWith('/raw/'),
         route => route.startsWith('/admin'),
         route => route.startsWith('/login'),
         route => route.startsWith('/dashboard'),

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -458,7 +458,7 @@ export default defineNuxtConfig({
   compatibilityDate: '2026-01-14',
   nitro: {
     prerender: {
-      crawlLinks: true,
+      crawlLinks: false,
       ignore: [
         route => route === '/modules' || route.startsWith('/modules/'),
         route => route.startsWith('/admin'),


### PR DESCRIPTION
## Summary
- Set `nitro.prerender.crawlLinks` to `false` so the build only prerenders explicit routes instead of crawling ~3000 linked pages.

## Test plan
- [ ] Compare Vercel build duration vs main
- [ ] Verify explicitly prerendered routes still work (`/`, sitemap, doc intros)