### PR TITLE
fix(agent): refocus prompt when panel reopens

### DIFF
--- a/layers/nuxi/app/components/agent/AgentChatPrompt.vue
+++ b/layers/nuxi/app/components/agent/AgentChatPrompt.vue
@@ -31,6 +31,12 @@ defineEmits<{
   restoreAttachment: [index: number]
 }>()
 
+const chatPromptRef = useTemplateRef('chatPromptRef')
+
+defineExpose({
+  focus: () => chatPromptRef.value?.textareaRef?.focus()
+})
+
 const promptStatus = computed(() => props.status ?? props.chat?.status ?? 'ready')
 const promptError = computed(() => props.error ?? props.chat?.error)
 const isSubmitDisabled = computed(() => {
@@ -41,6 +47,7 @@ const isSubmitDisabled = computed(() => {
 
 <template>
   <UChatPrompt
+    ref="chatPromptRef"
     v-model="input"
     :error="promptError"
     placeholder="Ask anything…"

--- a/layers/nuxi/app/components/agent/AgentPanelChat.vue
+++ b/layers/nuxi/app/components/agent/AgentPanelChat.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
 }>()
 
 const {
+  isOpen,
   faqQuestions,
   usage,
   rateLimitReached,
@@ -45,6 +46,17 @@ watch(() => chat.status, (status) => {
   else if (status === 'ready' && chat.messages.length > 0) nuxiMood.value = 'happy'
   else nuxiMood.value = 'idle'
 }, { immediate: true })
+
+// The docked sidebar keeps its content mounted when closed, so `autofocus`
+// only fires once. Refocus the prompt each time the panel reopens.
+const promptRef = useTemplateRef('promptRef')
+watch(isOpen, (value) => {
+  if (value) {
+    nextTick(() => {
+      promptRef.value?.focus()
+    })
+  }
+})
 
 onMounted(() => {
   const pendingPrompt = consumePendingPrompt()
@@ -113,6 +125,7 @@ onMounted(() => {
 
       <AgentChatPrompt
         v-else
+        ref="promptRef"
         v-model="input"
         v-bind="prompt"
         :chat="chat"


### PR DESCRIPTION
The docked agent sidebar keeps its content mounted when collapsed, so `autofocus` on the chat prompt only fires once. As a result, reopening the panel left the prompt without focus.

## Changes

- `AgentChatPrompt.vue` — expose a `focus()` method that focuses the underlying `UChatPrompt` textarea via a template ref.
- `AgentPanelChat.vue` — watch `isOpen` and refocus the prompt on `nextTick` when the panel reopens.

The full-screen dashboard chat pages remount per route, so their `autofocus` is unaffected.