### PR TITLE
Add npmx module links

### DIFF
--- a/app/components/module/ModuleItem.vue
+++ b/app/components/module/ModuleItem.vue
@@ -96,6 +96,12 @@ const items = computed(() => [
       icon: 'i-simple-icons-npm',
       to: `https://www.npmjs.com/package/${props.module.npm}`,
       target: '_blank'
+    },
+    {
+      label: 'View on npmx',
+      icon: 'i-simple-icons-npm',
+      to: `https://npmx.dev/package/${props.module.npm}`,
+      target: '_blank'
     }
   ]
 ])

--- a/app/components/module/ModuleItem.vue
+++ b/app/components/module/ModuleItem.vue
@@ -85,24 +85,26 @@ const items = computed(() => [
       to: `https://github.com/${props.module.repo}`,
       target: '_blank'
     },
-    {
-      label: 'View downloads',
-      icon: 'i-lucide-package',
-      to: `https://npm.chart.dev/${props.module.npm}`,
-      target: '_blank'
-    },
-    {
-      label: 'View on npm',
-      icon: 'i-simple-icons-npm',
-      to: `https://www.npmjs.com/package/${props.module.npm}`,
-      target: '_blank'
-    },
-    {
-      label: 'View on npmx',
-      icon: 'i-simple-icons-npm',
-      to: `https://npmx.dev/package/${props.module.npm}`,
-      target: '_blank'
-    }
+    ...(props.module.npm ? [
+      {
+        label: 'View downloads',
+        icon: 'i-lucide-package',
+        to: `https://npm.chart.dev/${props.module.npm}`,
+        target: '_blank'
+      },
+      {
+        label: 'View on npm',
+        icon: 'i-simple-icons-npm',
+        to: `https://www.npmjs.com/package/${props.module.npm}`,
+        target: '_blank'
+      },
+      {
+        label: 'View on npmx',
+        icon: 'i-simple-icons-npm',
+        to: `https://npmx.dev/package/${props.module.npm}`,
+        target: '_blank'
+      }
+    ] : [])
   ]
 ])
 </script>

--- a/app/components/module/ModuleItem.vue
+++ b/app/components/module/ModuleItem.vue
@@ -86,9 +86,15 @@ const items = computed(() => [
       target: '_blank'
     },
     {
-      label: 'View on npm',
+      label: 'View downloads',
       icon: 'i-lucide-package',
       to: `https://npm.chart.dev/${props.module.npm}`,
+      target: '_blank'
+    },
+    {
+      label: 'View on npm',
+      icon: 'i-simple-icons-npm',
+      to: `https://www.npmjs.com/package/${props.module.npm}`,
       target: '_blank'
     }
   ]

--- a/app/pages/modules/[slug].vue
+++ b/app/pages/modules/[slug].vue
@@ -34,6 +34,11 @@ const links = computed(() => module.value
       label: module.value.npm,
       to: `https://npmjs.org/package/${module.value.npm}`,
       target: '_blank'
+    }, module.value.npm && {
+      icon: 'i-simple-icons-npm',
+      label: 'npmx',
+      to: `https://npmx.dev/package/${module.value.npm}`,
+      target: '_blank'
     }, module.value.learn_more && {
       icon: 'i-lucide-link',
       label: 'Learn more',

--- a/server/routes/raw/modules.md.get.ts
+++ b/server/routes/raw/modules.md.get.ts
@@ -22,7 +22,8 @@ export default defineCachedEventHandler(async (event) => {
       const links = [
         mod.website ? `[Docs](${mod.website})` : '',
         mod.repo ? `[GitHub](https://github.com/${mod.repo})` : '',
-        `[npm](https://www.npmjs.com/package/${mod.npm})`
+        `[npm](https://www.npmjs.com/package/${mod.npm})`,
+        `[npmx](https://npmx.dev/package/${mod.npm})`
       ].filter(Boolean).join(' · ')
 
       lines.push(`### ${mod.npm}`, '')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Adds links to [npmx.dev](https://npmx.dev), a better package explorer for npm packages used by a lot of folks in the Nuxt community.

The new links are shown for modules in the module page sidebar and in the module card context menu. I also clarified the existing downloads link and added a separate direct link to npmjs.com.

I also added an npmx link in `server/routes/raw/modules.md.get.ts`, since npmx may eventually provide nicer package descriptions for LLMs: https://github.com/npmx-dev/npmx.dev/issues/725

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
