### PR TITLE
fix: consistent SEO titles and OG metadata across pages

### DIFF
--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -8,6 +8,9 @@ definePageMeta({
 })
 const { fetchList, articles } = useBlog()
 
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
+
 useHead({
   link: [
     {
@@ -20,16 +23,16 @@ useHead({
 })
 useSeoMeta({
   titleTemplate: '%s',
-  title: page.value.title,
-  description: page.value.description,
-  ogDescription: page.value.description,
-  ogTitle: page.value.title
+  title,
+  description,
+  ogDescription: description,
+  ogTitle: title
 })
 useCanonical()
 defineOgImage('Docs.takumi', {
-  headline: 'Blog',
-  title: page.value.title,
-  description: page.value.description
+  headline: 'Updates',
+  title,
+  description
 })
 
 await fetchList()

--- a/app/pages/changelog.vue
+++ b/app/pages/changelog.vue
@@ -6,19 +6,20 @@ definePageMeta({
 })
 
 const title = 'Changelog'
+const seoTitle = `Nuxt ${title}`
 const description = 'Discover the latest releases from Nuxt and the official modules.'
 
 useSeoMeta({
   titleTemplate: '%s',
-  title,
+  title: seoTitle,
   description,
   ogDescription: description,
-  ogTitle: title
+  ogTitle: seoTitle
 })
 useCanonical('/raw/changelog.md')
 defineOgImage('Docs.takumi', {
-  headline: 'Changelog',
-  title,
+  headline: 'Updates',
+  title: seoTitle,
   description
 })
 

--- a/app/pages/deploy/index.vue
+++ b/app/pages/deploy/index.vue
@@ -10,8 +10,8 @@ if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = page.value.title
-const description = page.value.description
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
 
 useSeoMeta({
   titleTemplate: '%s',
@@ -23,7 +23,7 @@ useSeoMeta({
 useCanonical()
 
 defineOgImage('Docs.takumi', {
-  title: 'Deploy Nuxt',
+  title,
   description
 })
 

--- a/app/pages/design-kit.vue
+++ b/app/pages/design-kit.vue
@@ -8,8 +8,8 @@ if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = page.value.title
-const description = page.value.description
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
 
 useSeoMeta({
   titleTemplate: '%s',

--- a/app/pages/enterprise/agencies/index.vue
+++ b/app/pages/enterprise/agencies/index.vue
@@ -12,14 +12,14 @@ if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = page.value.title
-const description = page.value.description
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
 useSeoMeta({
-  titleTemplate: '%s · Enterprise',
+  titleTemplate: '%s',
   title,
   description,
   ogDescription: description,
-  ogTitle: `${title} · Enterprise`
+  ogTitle: title
 })
 useCanonical()
 
@@ -42,8 +42,8 @@ await fetchList()
 <template>
   <UContainer v-if="page">
     <UPageHero
-      :title="title"
-      :description="description"
+      :title="page.title"
+      :description="page.description"
       :links="page.links"
     />
 

--- a/app/pages/enterprise/jobs.vue
+++ b/app/pages/enterprise/jobs.vue
@@ -12,11 +12,11 @@ if (!page.value) {
 const title = page.value.head?.title || page.value.title
 const description = page.value.head?.description || page.value.description
 useSeoMeta({
-  titleTemplate: '%s · Enterprise',
+  titleTemplate: '%s',
   title,
   description,
   ogDescription: description,
-  ogTitle: `${title} · Enterprise`
+  ogTitle: title
 })
 useCanonical()
 
@@ -32,8 +32,8 @@ await fetchList()
 <template>
   <UContainer v-if="page">
     <UPageHero
-      :title="title"
-      :description="description"
+      :title="page.title"
+      :description="page.description"
       :links="page.links"
       :ui="{
         title: 'text-left',

--- a/app/pages/enterprise/sponsors.vue
+++ b/app/pages/enterprise/sponsors.vue
@@ -12,19 +12,19 @@ if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = page.value.title
-const description = page.value.description
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
 useSeoMeta({
-  titleTemplate: '%s · Community',
+  titleTemplate: '%s',
   title,
   description,
   ogDescription: description,
-  ogTitle: `${title} · Community`
+  ogTitle: title
 })
 useCanonical()
 
 defineOgImage('Docs.takumi', {
-  headline: 'Community',
+  headline: 'Enterprise',
   title,
   description
 })
@@ -33,8 +33,8 @@ defineOgImage('Docs.takumi', {
 <template>
   <UContainer v-if="page">
     <UPageHero
-      :title="title"
-      :description="description"
+      :title="page.title"
+      :description="page.description"
       :links="page.links"
     />
 

--- a/app/pages/enterprise/support.vue
+++ b/app/pages/enterprise/support.vue
@@ -12,11 +12,11 @@ const title = page.value?.title
 const description = page.value?.description
 
 useSeoMeta({
-  titleTemplate: '%s · Enterprise',
+  titleTemplate: '%s',
   title,
   description,
   ogDescription: description,
-  ogTitle: `${title} · Enterprise`,
+  ogTitle: title,
   ogImage: '/assets/enterprise/support/social-card.png'
 })
 useCanonical()

--- a/app/pages/evals.vue
+++ b/app/pages/evals.vue
@@ -45,8 +45,8 @@ if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = page.value.title
-const description = page.value.description
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
 
 useSeoMeta({
   titleTemplate: '%s',
@@ -56,7 +56,10 @@ useSeoMeta({
   ogTitle: title
 })
 useCanonical()
-defineOgImage('Docs.takumi', { title, description })
+defineOgImage('Docs.takumi', {
+  title,
+  description
+})
 
 // Build experiment map by name
 const experimentMap = computed(() => {

--- a/app/pages/modules/index.vue
+++ b/app/pages/modules/index.vue
@@ -25,8 +25,8 @@ if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = page.value.title
-const description = page.value.description
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
 
 useSeoMeta({
   titleTemplate: '%s',

--- a/app/pages/newsletter.vue
+++ b/app/pages/newsletter.vue
@@ -8,8 +8,8 @@ if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = page.value.title
-const description = page.value.description
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
 useSeoMeta({
   titleTemplate: '%s',
   title,
@@ -27,8 +27,8 @@ defineOgImage('Docs.takumi', {
 <template>
   <UContainer v-if="page">
     <UPageHero
-      :title="title"
-      :description="description"
+      :title="page.title"
+      :description="page.description"
     >
       <template #links>
         <NewsletterForm class="flex-1 max-w-xs" :label="undefined" :description="undefined" />

--- a/app/pages/team.vue
+++ b/app/pages/team.vue
@@ -26,8 +26,12 @@ const [{ data: page }, { data: teams }] = await Promise.all([
   })
 ])
 
-const title = page.value!.title
-const description = page.value!.description
+if (!page.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
+}
+
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
 
 useSeoMeta({
   titleTemplate: '%s',
@@ -58,8 +62,8 @@ const icons = {
 <template>
   <UContainer v-if="page">
     <UPageHero
-      :title="title"
-      :description="description"
+      :title="page.title"
+      :description="page.description"
     />
 
     <UPage>

--- a/app/pages/templates.vue
+++ b/app/pages/templates.vue
@@ -11,8 +11,8 @@ if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = page.value.title
-const description = page.value.description
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
 
 const featuredTemplates = computed(() => templates.value?.filter(template => template.featured) || [])
 const baseTemplates = computed(() => templates.value?.filter(template => !template.featured) || [])
@@ -26,7 +26,6 @@ useSeoMeta({
 })
 useCanonical()
 defineOgImage('Docs.takumi', {
-  headline: 'Resources',
   title,
   description
 })
@@ -35,8 +34,8 @@ defineOgImage('Docs.takumi', {
 <template>
   <UContainer v-if="page">
     <UPageHero
-      :title="title"
-      :description="description"
+      :title="page.title"
+      :description="page.description"
       :links="page.links"
     />
     <UPage>

--- a/app/pages/video-courses.vue
+++ b/app/pages/video-courses.vue
@@ -11,8 +11,8 @@ if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = page.value.title
-const description = page.value.description
+const title = page.value.head?.title || page.value.title
+const description = page.value.head?.description || page.value.description
 
 useSeoMeta({
   titleTemplate: '%s',
@@ -32,8 +32,8 @@ defineOgImage('Docs.takumi', {
 <template>
   <UContainer v-if="page">
     <UPageHero
-      :title="title"
-      :description="description"
+      :title="page.title"
+      :description="page.description"
       :links="page.links"
     />
     <UPage>

--- a/content.config.ts
+++ b/content.config.ts
@@ -450,6 +450,10 @@ export default defineContentConfig({
       source: 'evals.yml',
       schema: z.object({
         title: z.string(),
+        head: z.object({
+          title: z.string().optional(),
+          description: z.string().optional()
+        }).optional(),
         description: z.string(),
         githubUrl: z.string().url()
       })

--- a/content/blog.yml
+++ b/content/blog.yml
@@ -1,4 +1,5 @@
 title: The Nuxt Blog
+head.title: Nuxt Blog
 navigation.title: Blog
 description: 'Read the latest news about all Nuxt solutions, from framework announcements to integration tutorials.'
 navigation.icon: i-lucide-newspaper

--- a/content/design-kit.md
+++ b/content/design-kit.md
@@ -1,5 +1,6 @@
 ---
 title: Design Kit
+head.title: Nuxt Design Kit
 head.description: Get the Nuxt assets such as Logo, Typography and Colors.
 description: Welcome to Nuxt design definition page. Identity was redefined by handpicking conscientiously colors, and shapes in order to express how easy & joyful Nuxt products are.
 navigation.icon: 'i-lucide-palette'

--- a/content/evals.yml
+++ b/content/evals.yml
@@ -1,3 +1,4 @@
 title: AI Agent Evaluations
+head.title: Nuxt AI Agent Evaluations
 description: "Performance results of AI coding agents on Nuxt code generation tasks, measuring success rate and execution time."
 githubUrl: "https://github.com/vercel/nuxt-evals"

--- a/content/team.yml
+++ b/content/team.yml
@@ -1,4 +1,5 @@
 title: The Nuxt Team
+head.title: Nuxt Team
 description: The development of Nuxt and its ecosystem is led by an international team.
 navigation: false
 links:

--- a/content/templates.yml
+++ b/content/templates.yml
@@ -1,4 +1,3 @@
-head.title: Nuxt Templates
 title: Nuxt Templates
 navigation.title: Templates
 description: 'Explore community templates to get up and running in a few seconds.'

--- a/content/video-courses.yml
+++ b/content/video-courses.yml
@@ -1,4 +1,3 @@
-head.title: Nuxt Video Courses
 title: Nuxt Video Courses
 navigation.title: Video Courses
 description: 'Watch video courses from the community to learn Vue 3 and Nuxt 3.'


### PR DESCRIPTION
## Summary

Makes page **SEO/OG titles** consistent across the site: every browser/OG title now contains **"Nuxt"**, while the visible hero `<h1>` keeps its natural wording. Achieved via the existing `head.title` mechanism (the [`showcase.vue`](https://github.com/nuxt/nuxt.com/blob/main/app/pages/showcase.vue) pattern) rather than polluting display titles.

## Changes

- **`head?.title || title` everywhere** — every landing page now consumes `head.title` for SEO and binds the `<UPageHero>` to `page.title` for display. Several pages were ignoring an already-defined `head.title` (e.g. `newsletter`, `agencies`), and `jobs` was even rendering the SEO title in its hero.
- **`head.title` normalized in content** — added where the display title lacked "Nuxt" (`blog` → `Nuxt Blog`, `team` → `Nuxt Team`, `design-kit` → `Nuxt Design Kit`, `evals` → `Nuxt AI Agent Evaluations`); removed the redundant ones (`templates`, `video-courses`). Rule: `head.title` exists only when it improves on the display title.
- **Schema** — added the optional `head` field to the `evals` collection.
- **Dropped title suffixes** — removed `· Enterprise` / `· Community` from the enterprise pages.
- **OG `headline` = nav section** — `Resources` (showcase, video-courses), `Enterprise` (agencies, jobs, sponsors), `Updates` (blog, changelog); top-level (`templates`, `modules`) and standalone pages have none; detail pages keep their per-item category.
- **team.vue** — uses the standard `if (!page.value) throw createError(...)` 404 guard instead of non-null assertions.

## Result

| Layer | Convention |
|---|---|
| Browser / OG title | `head?.title \|\| title` — always contains "Nuxt" |
| Hero H1 | `page.title` — natural wording |
| OG `headline` | nav section for section pages; none for top-level/standalone; category for detail pages |

## Test plan

- [x] `pnpm typecheck` passes
- [ ] Spot-check `document.title` / `og:title` on `/changelog`, `/evals`, `/design-kit`, `/newsletter`, `/enterprise/agencies`, `/enterprise/jobs` — all read the clean `Nuxt …` form, hero H1s unchanged

> [!NOTE]
> Out of scope but worth flagging: `/enterprise/support` is a dead route (content file missing → 404) yet still linked from the homepage CTA, ads fallback, and two blog posts. Not touched here.