### PR TITLE
chore(scripts): remove tmpdir prefix and add dev:ui script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "packageManager": "pnpm@11.9.0",
   "type": "module",
   "scripts": {
-    "dev": "TMPDIR=/tmp nuxt dev --ui-only",
-    "dev:full": "TMPDIR=/tmp nuxt dev",
+    "dev": "nuxt dev --ui-only",
+    "dev:ui": "EVE_BASE_URL=http://127.0.0.1:1 nuxt dev --ui-only",
+    "dev:full": "nuxt dev",
     "build": "NODE_OPTIONS='--max-old-space-size=8192' nuxt build",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",


### PR DESCRIPTION
This allow to start the dev server without Nuxi (eve)

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
