### PR TITLE
feat(evals): add First-Try Rate reliability column

### DIFF
--- a/app/pages/evals.vue
+++ b/app/pages/evals.vue
@@ -140,11 +140,15 @@ const filteredResults = computed(() => {
     rows = rows.map((r) => {
       const evals = r.evals.filter(e => selectedCategories.value.includes(getEvalCategory(e.evalPath)))
       const successes = evals.filter(e => e.result.success).length
+      const firstTries = evals.filter(e => e.result.firstRunSuccess).length
       return {
         ...r,
         evals,
         totalEvals: evals.length,
-        successRate: evals.length ? Math.round((successes / evals.length) * 100) : 0
+        successRate: evals.length ? Math.round((successes / evals.length) * 100) : 0,
+        // Recompute first-try rate from the filtered subset so the column and sort tiebreak
+        // match the shown evals; keep undefined for older data that lacks firstRunSuccess.
+        passAt1: r.passAt1 != null && evals.length ? firstTries / evals.length : undefined
       }
     }).sort(sortRows)
   }

--- a/app/pages/evals.vue
+++ b/app/pages/evals.vue
@@ -6,6 +6,8 @@ import rawData from '~~/public/agent-results.json'
 const UButton = resolveComponent('UButton')
 const UBadge = resolveComponent('UBadge')
 const UAvatar = resolveComponent('UAvatar')
+const UTooltip = resolveComponent('UTooltip')
+const UIcon = resolveComponent('UIcon')
 
 definePageMeta({
   heroBackground: 'opacity-70 -z-10'
@@ -19,6 +21,10 @@ interface EvalResultItem {
     duration: number
     evalPath: string
     timestamp: string
+    firstRunSuccess?: boolean
+    passedRuns?: number
+    totalRuns?: number
+    passRate?: number
   }
 }
 
@@ -28,6 +34,8 @@ interface Experiment {
   modelName: string
   agentHarness: string
   avgDuration?: number
+  passAt1?: number
+  avgPassRate?: number
 }
 
 interface ModelRow {
@@ -36,6 +44,7 @@ interface ModelRow {
   timestamp: string
   totalEvals: number
   successRate: number
+  passAt1?: number
   avgDuration: number
   evals: EvalResultItem[]
 }
@@ -71,9 +80,12 @@ const experimentMap = computed(() => {
   return map
 })
 
-// Sort by success rate, then most recent run date first
+// Sort by success rate, then first-try rate (tiebreak), then most recent run date first
 function sortRows(a: ModelRow, b: ModelRow): number {
   if (b.successRate !== a.successRate) return b.successRate - a.successRate
+  const aPassAt1 = a.passAt1 ?? -1
+  const bPassAt1 = b.passAt1 ?? -1
+  if (bPassAt1 !== aPassAt1) return bPassAt1 - aPassAt1
   return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
 }
 
@@ -90,6 +102,7 @@ const allResults = computed<ModelRow[]>(() => {
       timestamp: experiment?.timestamp || '',
       totalEvals: evals.length,
       successRate: evals.length ? Math.round((successes / evals.length) * 100) : 0,
+      passAt1: experiment?.passAt1,
       avgDuration: experiment?.avgDuration ?? 0,
       evals
     })
@@ -152,7 +165,8 @@ const modelIconMap: Record<string, string> = {
   gpt: 'i-simple-icons-openai',
   cursor: 'i-simple-icons-cursor',
   gemini: 'i-simple-icons-googlegemini',
-  devstral: 'i-simple-icons-mistralai'
+  devstral: 'i-simple-icons-mistralai',
+  minimax: 'i-simple-icons-minimax'
 }
 
 function getModelIcon(model: string): string {
@@ -242,6 +256,22 @@ const columns: TableColumn<ModelRow>[] = [
       }
     },
     cell: ({ row }) => h('span', {}, `${row.original.successRate}%`)
+  },
+  {
+    accessorKey: 'passAt1',
+    header: () => h(UTooltip, {
+      text: 'Passed on the first attempt. Each eval allows up to 4 attempts; Success counts an eval as passed if any attempt succeeds.'
+    }, () => h('span', { class: 'inline-flex items-center gap-1' }, [
+      h('span', {}, 'First-Try Rate'),
+      h(UIcon, { name: 'i-lucide-info', class: 'size-3.5 text-dimmed' })
+    ])),
+    meta: {
+      class: {
+        th: 'text-right',
+        td: 'text-right text-muted'
+      }
+    },
+    cell: ({ row }) => h('span', {}, row.original.passAt1 != null ? `${Math.round(row.original.passAt1 * 100)}%` : '—')
   }
 ]
 
@@ -260,10 +290,24 @@ const evalColumns: TableColumn<EvalResultItem>[] = [
         td: 'text-center'
       }
     },
-    cell: ({ row }) => h(UBadge, {
-      color: row.original.result.success ? 'success' : 'error',
-      variant: 'subtle'
-    }, () => row.original.result.success ? 'Pass' : 'Fail')
+    cell: ({ row }) => {
+      const { success, passedRuns, totalRuns } = row.original.result
+      const children = [
+        h(UBadge, {
+          color: success ? 'success' : 'error',
+          variant: 'subtle'
+        }, () => success ? 'Pass' : 'Fail')
+      ]
+      if (totalRuns && totalRuns > 1) {
+        children.push(h(UTooltip, {
+          text: `${passedRuns} of ${totalRuns} attempts passed`
+        }, () => h(UBadge, {
+          color: 'neutral',
+          variant: 'subtle'
+        }, () => `${passedRuns}/${totalRuns}`)))
+      }
+      return h('div', { class: 'flex items-center justify-center gap-1.5' }, children)
+    }
   },
   {
     id: 'duration',
@@ -371,6 +415,14 @@ const evalColumns: TableColumn<EvalResultItem>[] = [
             />
           </template>
         </UTable>
+
+        <div class="mt-4 text-sm text-dimmed text-pretty text-justify bg-elevated/50 p-4 rounded-lg">
+          Each evaluation is attempted up to 4 times.
+          <span class="text-default font-medium">Success Rate</span> is the percentage of evals that passed on at least one attempt;
+          <span class="text-default font-medium">First-Try Rate</span> is the percentage that passed on the first attempt, used to break ties between models with the same success rate.
+          <span class="text-default font-medium">Avg Duration</span> is the mean time an agent took per eval. Expand a row to see per-eval results, where a
+          <span class="text-default font-medium">1/3</span> badge means the eval failed twice before passing.
+        </div>
       </UContainer>
     </UPageBody>
   </div>

--- a/public/agent-results.json
+++ b/public/agent-results.json
@@ -1,332 +1,927 @@
 {
   "metadata": {
-    "exportedAt": "2026-06-03T08:39:40.824Z",
+    "exportedAt": "2026-07-03T16:09:26.325Z",
     "experiments": [
       {
+        "name": "claude-fable-5",
+        "timestamp": "2026-07-03T14:56:22.157Z",
+        "modelName": "Claude Fable 5",
+        "agentHarness": "Claude Code",
+        "avgDuration": 298.8140172413793,
+        "passAt1": 0.9655172413793104,
+        "avgPassRate": 0.9827586206896551
+      },
+      {
         "name": "claude-opus-4.6",
-        "timestamp": "2026-04-02T20:14:43.874Z",
+        "timestamp": "2026-07-03T14:56:22.172Z",
         "modelName": "Claude Opus 4.6",
         "agentHarness": "Claude Code",
-        "avgDuration": 244.59131
+        "avgDuration": 244.85190229885058,
+        "passAt1": 0.8275862068965517,
+        "avgPassRate": 0.8850574712643677
       },
       {
         "name": "claude-opus-4.7",
-        "timestamp": "2026-04-16T15:34:17.962Z",
+        "timestamp": "2026-07-03T14:56:22.189Z",
         "modelName": "Claude Opus 4.7",
         "agentHarness": "Claude Code",
-        "avgDuration": 190.49337333333332
+        "avgDuration": 215.7265689655173,
+        "passAt1": 0.896551724137931,
+        "avgPassRate": 0.9195402298850573
       },
       {
         "name": "claude-opus-4.8",
-        "timestamp": "2026-06-02T20:27:19.775Z",
+        "timestamp": "2026-07-03T14:56:22.202Z",
         "modelName": "Claude Opus 4.8",
         "agentHarness": "Claude Code",
-        "avgDuration": 244.65525
+        "avgDuration": 261.3666724137931,
+        "passAt1": 0.896551724137931,
+        "avgPassRate": 0.9396551724137931
       },
       {
         "name": "claude-sonnet-4.5",
-        "timestamp": "2026-04-02T20:14:43.892Z",
+        "timestamp": "2026-07-03T14:56:22.217Z",
         "modelName": "Claude Sonnet 4.5",
         "agentHarness": "Claude Code",
-        "avgDuration": 225.92435999999998
+        "avgDuration": 240.76111781609194,
+        "passAt1": 0.4827586206896552,
+        "avgPassRate": 0.5287356321839081
       },
       {
         "name": "claude-sonnet-4.6",
-        "timestamp": "2026-04-02T20:14:43.910Z",
+        "timestamp": "2026-07-03T14:56:22.237Z",
         "modelName": "Claude Sonnet 4.6",
         "agentHarness": "Claude Code",
-        "avgDuration": 238.40506
+        "avgDuration": 254.11203448275862,
+        "passAt1": 0.8275862068965517,
+        "avgPassRate": 0.8793103448275862
       },
       {
-        "name": "cursor-composer-1.5",
-        "timestamp": "2026-04-02T20:14:43.926Z",
-        "modelName": "Cursor Composer 1.5",
-        "agentHarness": "Cursor",
-        "avgDuration": 201.56997
+        "name": "claude-sonnet-5",
+        "timestamp": "2026-07-03T15:14:44.287Z",
+        "modelName": "Claude Sonnet 5",
+        "agentHarness": "Claude Code",
+        "avgDuration": 292.09031034482757,
+        "passAt1": 1,
+        "avgPassRate": 1
       },
       {
         "name": "cursor-composer-2.0",
-        "timestamp": "2026-04-02T20:14:43.942Z",
+        "timestamp": "2026-07-03T14:56:22.253Z",
         "modelName": "Cursor Composer 2.0",
         "agentHarness": "Cursor",
-        "avgDuration": 221.46936
+        "avgDuration": 273.9128965517241,
+        "passAt1": 0.9655172413793104,
+        "avgPassRate": 0.9827586206896551
       },
       {
         "name": "cursor-composer-2.5",
-        "timestamp": "2026-06-02T10:24:23.855Z",
+        "timestamp": "2026-07-03T14:56:22.267Z",
         "modelName": "Cursor Composer 2.5",
         "agentHarness": "Cursor",
-        "avgDuration": 253.29104999999998
-      },
-      {
-        "name": "devstral-2",
-        "timestamp": "2026-04-02T20:14:43.959Z",
-        "modelName": "Devstral 2",
-        "agentHarness": "OpenCode",
-        "avgDuration": 213.26004999999998
+        "avgDuration": 263.3075344827586,
+        "passAt1": 0.896551724137931,
+        "avgPassRate": 0.9310344827586207
       },
       {
         "name": "gemini-3-pro-preview",
-        "timestamp": "2026-04-02T20:14:43.974Z",
+        "timestamp": "2026-07-03T14:56:22.282Z",
         "modelName": "Gemini 3 Pro Preview",
-        "agentHarness": "Gemini CLI",
-        "avgDuration": 365.90684999999996
+        "agentHarness": "OpenCode",
+        "avgDuration": 291.646,
+        "passAt1": 0.896551724137931,
+        "avgPassRate": 0.9425287356321839
       },
       {
         "name": "gemini-3.1-pro-preview",
-        "timestamp": "2026-04-02T20:14:43.990Z",
+        "timestamp": "2026-07-03T14:56:22.295Z",
         "modelName": "Gemini 3.1 Pro Preview",
-        "agentHarness": "Gemini CLI",
-        "avgDuration": 345.5080566666667
+        "agentHarness": "OpenCode",
+        "avgDuration": 289.4584827586207,
+        "passAt1": 0.8275862068965517,
+        "avgPassRate": 0.8821839080459771
       },
       {
         "name": "gpt-5.3-codex-xhigh",
-        "timestamp": "2026-04-03T08:00:32.409Z",
+        "timestamp": "2026-07-03T14:56:22.309Z",
         "modelName": "GPT 5.3 Codex (xhigh)",
         "agentHarness": "Codex",
-        "avgDuration": 246.02578666666668
+        "avgDuration": 276.5169597701149,
+        "passAt1": 0.896551724137931,
+        "avgPassRate": 0.942528735632184
       },
       {
         "name": "gpt-5.4-xhigh",
-        "timestamp": "2026-04-02T20:14:44.028Z",
+        "timestamp": "2026-07-03T14:56:22.325Z",
         "modelName": "GPT 5.4 (xhigh)",
         "agentHarness": "Codex",
-        "avgDuration": 313.64658000000003
+        "avgDuration": 302.56503735632185,
+        "passAt1": 0.7586206896551724,
+        "avgPassRate": 0.8074712643678161
+      },
+      {
+        "name": "gpt-5.5-pro",
+        "timestamp": "2026-07-03T14:56:22.340Z",
+        "modelName": "GPT 5.5 Pro",
+        "agentHarness": "Codex",
+        "avgDuration": 666.0175775862068,
+        "passAt1": 0.9310344827586207,
+        "avgPassRate": 0.9425287356321839
+      },
+      {
+        "name": "kimi-k2.6",
+        "timestamp": "2026-07-03T14:56:22.354Z",
+        "modelName": "Kimi K2.6",
+        "agentHarness": "OpenCode",
+        "avgDuration": 285.4723218390805,
+        "passAt1": 0.7931034482758621,
+        "avgPassRate": 0.8505747126436781
+      },
+      {
+        "name": "kimi-k2.7-code",
+        "timestamp": "2026-07-03T15:27:06.357Z",
+        "modelName": "Kimi K2.7 Code",
+        "agentHarness": "OpenCode",
+        "avgDuration": 327.0041465517241,
+        "passAt1": 0.8275862068965517,
+        "avgPassRate": 0.8908045977011495
       },
       {
         "name": "minimax-m2.7",
-        "timestamp": "2026-06-01T09:33:39.442Z",
+        "timestamp": "2026-07-03T14:56:22.372Z",
         "modelName": "MiniMax M2.7",
         "agentHarness": "OpenCode",
-        "avgDuration": 259.46938
+        "avgDuration": 204.88056896551726,
+        "passAt1": 0.3103448275862069,
+        "avgPassRate": 0.38218390804597696
+      },
+      {
+        "name": "minimax-m3",
+        "timestamp": "2026-07-03T15:57:38.098Z",
+        "modelName": "MiniMax M3",
+        "agentHarness": "OpenCode",
+        "avgDuration": 224.8897844827586,
+        "passAt1": 0.8620689655172413,
+        "avgPassRate": 0.9051724137931034
       }
     ]
   },
   "results": {
-    "claude-opus-4.6": [
+    "claude-fable-5": [
       {
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 174211,
+          "duration": 218530,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 174966,
+          "duration": 214347,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 206071,
+          "duration": 427986,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-02T20:14:43.874Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
           "success": true,
-          "duration": 176593.5,
+          "duration": 271821,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T14:56:22.157Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
           "success": true,
-          "duration": 227083,
+          "duration": 367199.5,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-02T14:51:18.103Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 150880,
+          "duration": 197342,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
           "success": true,
-          "duration": 222817,
+          "duration": 232923,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-02-24T15:02:21.602Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 145664,
+          "duration": 175493,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": true,
-          "duration": 260603.99999999997,
+          "duration": 428143,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 177938,
+          "duration": 222651,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-02-24T15:02:21.602Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 214283,
+          "duration": 233750,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
-          "success": false,
-          "duration": 151682.75,
+          "success": true,
+          "duration": 221743,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-02T20:14:43.874Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 345470,
+          "duration": 255079,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-02-24T15:02:21.602Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 196578,
+          "duration": 261125.99999999997,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-02T20:14:43.874Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
           "success": true,
-          "duration": 228090,
+          "duration": 290862,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 229969,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 209451,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 299271,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.157Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 314526,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": true,
-          "duration": 335647,
+          "duration": 425816,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
           "success": true,
-          "duration": 301179,
+          "duration": 321095,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
           "success": true,
-          "duration": 295579.5,
+          "duration": 329512,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
           "success": true,
-          "duration": 316816,
+          "duration": 356780,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-02-24T15:02:21.602Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
           "success": true,
-          "duration": 330416,
+          "duration": 408053,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
           "success": true,
-          "duration": 327289,
+          "duration": 294277,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
           "success": true,
-          "duration": 271454,
+          "duration": 385910,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 264771,
+          "duration": 395758,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": true,
-          "duration": 335986.99999999994,
+          "duration": 357662,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 282713,
+          "duration": 318531,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-02-24T14:42:38.411Z"
+          "timestamp": "2026-07-03T13:08:55.474Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      }
+    ],
+    "claude-opus-4.6": [
+      {
+        "evalPath": "nuxt-000-fix-data-fetching",
+        "result": {
+          "success": true,
+          "duration": 179125,
+          "evalPath": "nuxt-000-fix-data-fetching",
+          "timestamp": "2026-06-30T15:09:40.394Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-001-prefer-nuxt-link",
+        "result": {
+          "success": true,
+          "duration": 172664,
+          "evalPath": "nuxt-001-prefer-nuxt-link",
+          "timestamp": "2026-06-30T14:12:50.500Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-002-state-composables",
+        "result": {
+          "success": true,
+          "duration": 294745,
+          "evalPath": "nuxt-002-state-composables",
+          "timestamp": "2026-06-30T14:12:50.500Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-003-page-meta",
+        "result": {
+          "success": true,
+          "duration": 218944.6666666667,
+          "evalPath": "nuxt-003-page-meta",
+          "timestamp": "2026-07-03T14:56:22.172Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-004-error-handling",
+        "result": {
+          "success": true,
+          "duration": 230562,
+          "evalPath": "nuxt-004-error-handling",
+          "timestamp": "2026-07-03T13:08:55.494Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-005-fix-seo-meta",
+        "result": {
+          "success": true,
+          "duration": 159347,
+          "evalPath": "nuxt-005-fix-seo-meta",
+          "timestamp": "2026-06-30T14:12:50.500Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-006-runtime-config",
+        "result": {
+          "success": true,
+          "duration": 193475,
+          "evalPath": "nuxt-006-runtime-config",
+          "timestamp": "2026-06-30T14:12:50.500Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-007-avoid-redundant-ref",
+        "result": {
+          "success": true,
+          "duration": 172940,
+          "evalPath": "nuxt-007-avoid-redundant-ref",
+          "timestamp": "2026-06-30T14:12:50.500Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-008-fix-exposed-secret",
+        "result": {
+          "success": true,
+          "duration": 209426,
+          "evalPath": "nuxt-008-fix-exposed-secret",
+          "timestamp": "2026-07-03T13:08:55.494Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-009-cache-api-response",
+        "result": {
+          "success": true,
+          "duration": 165374,
+          "evalPath": "nuxt-009-cache-api-response",
+          "timestamp": "2026-07-03T13:08:55.494Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-010-fix-watch-fetch",
+        "result": {
+          "success": true,
+          "duration": 192252,
+          "evalPath": "nuxt-010-fix-watch-fetch",
+          "timestamp": "2026-07-03T13:08:55.494Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-011-fix-sequential-fetching",
+        "result": {
+          "success": true,
+          "duration": 170495,
+          "evalPath": "nuxt-011-fix-sequential-fetching",
+          "timestamp": "2026-06-30T14:12:50.500Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
+        "result": {
+          "success": true,
+          "duration": 347485,
+          "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
+          "timestamp": "2026-06-30T14:12:50.500Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-013-prefer-nuxt-image",
+        "result": {
+          "success": true,
+          "duration": 194055,
+          "evalPath": "nuxt-013-prefer-nuxt-image",
+          "timestamp": "2026-06-11T12:17:50.688Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-014-prefer-use-cookie",
+        "result": {
+          "success": true,
+          "duration": 181366,
+          "evalPath": "nuxt-014-prefer-use-cookie",
+          "timestamp": "2026-07-03T13:08:55.494Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 192059,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.229Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": false,
+          "duration": 158332.49999999997,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.494Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 189581,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.172Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 245196.5,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.330Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-content-000-navigation",
+        "result": {
+          "success": true,
+          "duration": 333362,
+          "evalPath": "nuxt-content-000-navigation",
+          "timestamp": "2026-06-11T12:17:50.688Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-content-001-data-collection",
+        "result": {
+          "success": true,
+          "duration": 306913,
+          "evalPath": "nuxt-content-001-data-collection",
+          "timestamp": "2026-06-11T12:17:50.688Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-000-theming",
+        "result": {
+          "success": true,
+          "duration": 305873,
+          "evalPath": "nuxt-ui-000-theming",
+          "timestamp": "2026-06-11T12:17:50.688Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-001-fix-raw-html-page",
+        "result": {
+          "success": true,
+          "duration": 350793,
+          "evalPath": "nuxt-ui-001-fix-raw-html-page",
+          "timestamp": "2026-06-11T12:17:50.688Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-002-dashboard-layout",
+        "result": {
+          "success": true,
+          "duration": 334772,
+          "evalPath": "nuxt-ui-002-dashboard-layout",
+          "timestamp": "2026-06-11T12:17:50.688Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-003-fix-raw-form",
+        "result": {
+          "success": true,
+          "duration": 307078,
+          "evalPath": "nuxt-ui-003-fix-raw-form",
+          "timestamp": "2026-06-11T12:17:50.688Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-004-table",
+        "result": {
+          "success": true,
+          "duration": 314649,
+          "evalPath": "nuxt-ui-004-table",
+          "timestamp": "2026-06-11T12:17:50.688Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-005-modal",
+        "result": {
+          "success": true,
+          "duration": 300200,
+          "evalPath": "nuxt-ui-005-modal",
+          "timestamp": "2026-07-03T13:08:55.494Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-006-command-palette",
+        "result": {
+          "success": true,
+          "duration": 342904.5,
+          "evalPath": "nuxt-ui-006-command-palette",
+          "timestamp": "2026-06-11T12:17:50.688Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-007-dropdown-menu",
+        "result": {
+          "success": true,
+          "duration": 336736,
+          "evalPath": "nuxt-ui-007-dropdown-menu",
+          "timestamp": "2026-06-11T12:17:50.688Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
@@ -335,225 +930,377 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 165149,
+          "duration": 158466,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-30T15:09:40.405Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 97997,
+          "duration": 165453,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-30T14:12:50.511Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 140477.50000000003,
+          "duration": 275373,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-30T14:12:50.511Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
-          "success": true,
-          "duration": 258795.00000000003,
+          "success": false,
+          "duration": 217019.5,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-07-03T14:56:22.189Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
-          "success": false,
-          "duration": 192839.00000000003,
+          "success": true,
+          "duration": 178835,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-07-03T12:55:20.922Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 148220,
+          "duration": 162467,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-30T14:12:50.511Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
           "success": true,
-          "duration": 176627,
+          "duration": 165827,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-30T14:12:50.511Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 159841,
+          "duration": 161220,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-30T14:12:50.511Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": true,
-          "duration": 259461,
+          "duration": 235302,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-07-03T12:55:20.922Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 150483,
+          "duration": 154157,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-07-03T12:55:20.922Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 173367,
+          "duration": 175794,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-07-03T12:55:20.922Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
-          "success": false,
-          "duration": 133488.5,
+          "success": true,
+          "duration": 159757,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-30T14:12:50.511Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 144918,
+          "duration": 204111.33333333337,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-30T14:12:50.511Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 185920,
+          "duration": 207514,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-11T14:37:41.428Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
           "success": true,
-          "duration": 176685,
+          "duration": 169958,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-07-03T12:55:20.922Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 183497,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.242Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 147146,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T12:55:20.922Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 161533,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.189Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 216759,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.356Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": true,
-          "duration": 210357.6666666667,
+          "duration": 290946,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-11T14:37:41.428Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
           "success": true,
-          "duration": 274813,
+          "duration": 267800,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-11T14:37:41.428Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
-          "success": false,
-          "duration": 207623.74999999997,
+          "success": true,
+          "duration": 279741,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-11T14:37:41.428Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
           "success": true,
-          "duration": 218076.49999999997,
+          "duration": 279651.6666666667,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-11T14:37:41.428Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
           "success": true,
-          "duration": 270466,
+          "duration": 290508,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-11T14:37:41.428Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
           "success": true,
-          "duration": 239915,
+          "duration": 267586,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-11T14:37:41.428Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
           "success": true,
-          "duration": 185466.5,
+          "duration": 280160,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-11T14:37:41.428Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 273727,
+          "duration": 257903.00000000003,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-07-03T12:55:20.922Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": true,
-          "duration": 176821.25,
+          "duration": 287475,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-11T14:37:41.428Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 140799.66666666666,
+          "duration": 254111,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-04-16T15:34:17.962Z"
+          "timestamp": "2026-06-11T14:37:41.428Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
@@ -562,225 +1309,377 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 169791,
+          "duration": 191974,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-30T15:09:40.416Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 158702,
+          "duration": 171290,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-30T14:12:50.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 272647,
+          "duration": 339356,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-30T14:12:50.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
           "success": true,
-          "duration": 246586,
+          "duration": 242714,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-07-03T14:56:22.202Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
           "success": true,
-          "duration": 190398.5,
+          "duration": 279717.50000000006,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-07-03T13:08:55.523Z",
+          "passRate": 0.25,
+          "passedRuns": 1,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 139902,
+          "duration": 162596,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-30T14:12:50.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
           "success": true,
-          "duration": 180380,
+          "duration": 179040,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-30T14:12:50.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 145806,
+          "duration": 159741,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-30T14:12:50.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": true,
-          "duration": 251389,
+          "duration": 368896,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-07-03T13:08:55.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 150833,
+          "duration": 160789,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-07-03T13:08:55.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 173659,
+          "duration": 210911,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-07-03T13:08:55.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
-          "success": false,
-          "duration": 153040.5,
+          "success": true,
+          "duration": 161247,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-30T14:12:50.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 260442.99999999997,
+          "duration": 293445,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-30T14:12:50.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 212787,
+          "duration": 233514,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-11T14:28:10.369Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
           "success": true,
-          "duration": 166251,
+          "duration": 201703,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-07-03T13:08:55.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 182460,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.253Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 168042,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 315515,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.202Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 219805,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.378Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": true,
-          "duration": 303093,
+          "duration": 361738,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-11T14:28:10.369Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
           "success": true,
-          "duration": 248663,
+          "duration": 293817,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-11T14:28:10.369Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
-          "success": false,
-          "duration": 396097.74999999994,
+          "success": true,
+          "duration": 340298,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-06-02T20:27:19.775Z"
+          "timestamp": "2026-06-11T14:28:10.369Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
           "success": true,
-          "duration": 294627.5,
+          "duration": 347642,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-11T14:28:10.369Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
           "success": true,
-          "duration": 296385,
+          "duration": 332252,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-11T14:28:10.369Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
           "success": true,
-          "duration": 285657.00000000006,
+          "duration": 299126,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-11T14:28:10.369Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
           "success": true,
-          "duration": 285570,
+          "duration": 307484,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-11T14:28:10.369Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 324381,
+          "duration": 400369,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-07-03T13:08:55.523Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": true,
-          "duration": 438331,
+          "duration": 327245,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-11T14:28:10.369Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 370961,
+          "duration": 326907,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-06-02T10:24:23.767Z"
+          "timestamp": "2026-06-11T14:28:10.369Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
@@ -789,225 +1688,377 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 173954,
+          "duration": 179967,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-30T15:09:40.429Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 178303,
+          "duration": 178321,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-30T14:12:50.535Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 222421,
+          "duration": 278227,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-02T20:14:43.892Z"
+          "timestamp": "2026-06-30T14:12:50.535Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
           "success": false,
-          "duration": 173176.75,
+          "duration": 192623.25,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-07-03T14:56:22.217Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
           "success": false,
-          "duration": 321378.74999999994,
+          "duration": 325770.25000000006,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-02T14:51:18.118Z"
+          "timestamp": "2026-07-03T13:08:55.538Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 154083,
+          "duration": 172551,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-30T14:12:50.535Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
-          "success": false,
-          "duration": 227200.75,
+          "success": true,
+          "duration": 159555.5,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-02-24T15:02:21.619Z"
+          "timestamp": "2026-06-30T14:12:50.535Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 136523,
+          "duration": 175971,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-30T14:12:50.535Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": true,
-          "duration": 200460,
+          "duration": 183575,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-07-03T13:08:55.538Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 164911,
+          "duration": 173934,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-02-24T15:02:21.619Z"
+          "timestamp": "2026-07-03T13:08:55.538Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 165032,
+          "duration": 181478,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-07-03T13:08:55.538Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
-          "success": false,
-          "duration": 171395.75,
+          "success": true,
+          "duration": 176191,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-02T20:14:43.892Z"
+          "timestamp": "2026-06-30T14:12:50.535Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 259696.00000000003,
+          "duration": 219513,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-02-24T15:02:21.619Z"
+          "timestamp": "2026-06-30T14:12:50.535Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 184596,
+          "duration": 199616,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-02T20:14:43.892Z"
+          "timestamp": "2026-06-11T15:11:17.070Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
           "success": true,
-          "duration": 196294.24999999997,
+          "duration": 205204,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-07-03T13:08:55.538Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": false,
+          "duration": 194482.25,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.267Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 165181,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.538Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": false,
+          "duration": 185609,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.217Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": false,
+          "duration": 190120.99999999997,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.393Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": false,
-          "duration": 315850.5,
+          "duration": 497660.5,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-11T15:11:17.070Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
-          "success": false,
-          "duration": 242146.75,
+          "success": true,
+          "duration": 456112.6666666666,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-11T15:11:17.070Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
           "success": true,
-          "duration": 249234,
+          "duration": 263856.5,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-11T15:11:17.070Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
           "success": false,
-          "duration": 247716.25,
+          "duration": 262721.25,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-02-24T15:02:21.619Z"
+          "timestamp": "2026-06-11T15:11:17.070Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
-          "success": true,
-          "duration": 266937,
+          "success": false,
+          "duration": 295387.25,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-11T15:11:17.070Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
           "success": true,
-          "duration": 217736.49999999997,
+          "duration": 260699,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-11T15:11:17.070Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
           "success": false,
-          "duration": 243867.25,
+          "duration": 300317.25,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-11T15:11:17.070Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": false,
-          "duration": 346462.25,
+          "duration": 314555.50000000006,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-07-03T13:08:55.538Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": false,
-          "duration": 370035.25,
+          "duration": 317681.74999999994,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-11T15:11:17.070Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
-          "success": true,
-          "duration": 218698,
+          "success": false,
+          "duration": 275190.50000000006,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-02-24T14:42:38.432Z"
+          "timestamp": "2026-06-11T15:11:17.070Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       }
     ],
@@ -1016,452 +2067,756 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 95021,
+          "duration": 171311,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-30T15:09:40.440Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 124067,
+          "duration": 175346,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-30T14:12:50.546Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 213467,
+          "duration": 308492,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-02T20:14:43.910Z"
+          "timestamp": "2026-06-30T14:12:50.546Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
           "success": true,
-          "duration": 199692,
+          "duration": 192594.49999999997,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-07-03T14:56:22.237Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
           "success": true,
-          "duration": 217197,
+          "duration": 209187,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-02T14:51:18.133Z"
+          "timestamp": "2026-07-03T13:08:55.559Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 98158.99999999999,
+          "duration": 164311.50000000003,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-30T14:12:50.546Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
           "success": true,
-          "duration": 149207,
+          "duration": 220041,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-02-24T15:02:21.635Z"
+          "timestamp": "2026-06-30T14:12:50.546Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 132563.5,
+          "duration": 162507,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-30T14:12:50.546Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": true,
-          "duration": 366692,
+          "duration": 187181,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-07-03T13:08:55.559Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 145906,
+          "duration": 166968,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-02-24T15:02:21.635Z"
+          "timestamp": "2026-07-03T13:08:55.559Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 293994,
+          "duration": 189572,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-07-03T13:08:55.559Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
-          "success": false,
-          "duration": 192526.75,
+          "success": true,
+          "duration": 172103,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-02T20:14:43.910Z"
+          "timestamp": "2026-06-30T14:12:50.546Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 356283,
+          "duration": 241129,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-02-24T15:02:21.635Z"
+          "timestamp": "2026-06-30T14:12:50.546Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 202553,
+          "duration": 200371,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-02T20:14:43.910Z"
+          "timestamp": "2026-06-11T15:11:17.082Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
           "success": true,
-          "duration": 278639,
+          "duration": 186904,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-07-03T13:08:55.559Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 181694,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.277Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": false,
+          "duration": 160393.50000000003,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.559Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 205765,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.237Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 177911,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.408Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": true,
-          "duration": 219623.5,
+          "duration": 427871,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-11T15:11:17.082Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
           "success": true,
-          "duration": 308190,
+          "duration": 272707,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-11T15:11:17.082Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
           "success": true,
-          "duration": 258980.00000000003,
+          "duration": 350554,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-11T15:11:17.082Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
           "success": false,
-          "duration": 314627.25,
+          "duration": 309729.5,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-02-24T15:02:21.635Z"
+          "timestamp": "2026-06-11T15:11:17.082Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
           "success": true,
-          "duration": 288882,
+          "duration": 405813,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-11T15:11:17.082Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
           "success": true,
-          "duration": 176197.99999999997,
+          "duration": 271305,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-11T15:11:17.082Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
           "success": true,
-          "duration": 187553.5,
+          "duration": 354992,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-11T15:11:17.082Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 359734,
+          "duration": 437977,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-07-03T13:08:55.559Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": true,
-          "duration": 456897,
+          "duration": 483156,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-11T15:11:17.082Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 323474,
+          "duration": 381363,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-02-24T14:42:38.440Z"
+          "timestamp": "2026-06-11T15:11:17.082Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
-    "cursor-composer-1.5": [
+    "claude-sonnet-5": [
       {
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 116112,
+          "duration": 195893,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 182397,
+          "duration": 286708,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 183088,
+          "duration": 322372,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-02T20:14:43.926Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
-          "success": false,
-          "duration": 211808.25000000003,
+          "success": true,
+          "duration": 221700,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
           "success": true,
-          "duration": 195340,
+          "duration": 292476,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-02T14:51:18.147Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 200702,
+          "duration": 145997,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
           "success": true,
-          "duration": 224528,
+          "duration": 212823,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-02-24T15:02:21.652Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 118372,
+          "duration": 159857,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": true,
-          "duration": 239098,
+          "duration": 442419,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 150891,
+          "duration": 181529,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-02-24T15:02:21.652Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 101094.25,
+          "duration": 250538,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
-          "success": false,
-          "duration": 156957,
+          "success": true,
+          "duration": 169335,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-02T20:14:43.926Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 223084,
+          "duration": 274210,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-02-24T15:02:21.652Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 169152,
+          "duration": 233732,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-02T20:14:43.926Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
           "success": true,
-          "duration": 257995,
+          "duration": 211335,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 181757,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 177577,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 280403,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 420015,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": true,
-          "duration": 297084.5,
+          "duration": 571111,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-02-24T15:02:21.652Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
-          "success": false,
-          "duration": 116444.75,
+          "success": true,
+          "duration": 322453,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
           "success": true,
-          "duration": 286707,
+          "duration": 292988,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
           "success": true,
-          "duration": 267501,
+          "duration": 370624,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-02-24T15:02:21.652Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
           "success": true,
-          "duration": 307138,
+          "duration": 337804,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
-          "success": false,
-          "duration": 104258.25,
+          "success": true,
+          "duration": 408539,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
-          "success": false,
-          "duration": 243965.75,
+          "success": true,
+          "duration": 328093,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 286337.50000000006,
+          "duration": 410037,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": true,
-          "duration": 200724,
+          "duration": 370809,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 198470,
+          "duration": 397485,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-02-24T14:42:38.447Z"
+          "timestamp": "2026-07-03T15:14:44.287Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
@@ -1470,225 +2825,377 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 133241,
+          "duration": 184806,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-30T15:09:40.450Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 121815,
+          "duration": 186880,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-30T14:12:50.555Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 248055,
+          "duration": 241154,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-02T20:14:43.942Z"
+          "timestamp": "2026-06-30T14:12:50.555Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
-          "success": false,
-          "duration": 193793.25,
+          "success": true,
+          "duration": 256031,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-07-03T14:56:22.253Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
           "success": true,
-          "duration": 247299,
+          "duration": 347703,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-02T14:51:18.160Z"
+          "timestamp": "2026-07-03T13:08:55.602Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 195321,
+          "duration": 163606,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-30T14:12:50.555Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
           "success": true,
-          "duration": 161743,
+          "duration": 253404,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-30T14:12:50.555Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 115218,
+          "duration": 172513,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-30T14:12:50.555Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": true,
-          "duration": 164009,
+          "duration": 405936,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-07-03T13:08:55.602Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 126006,
+          "duration": 223781,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-07-03T13:08:55.602Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 162871,
+          "duration": 250415,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-07-03T13:08:55.602Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
-          "success": false,
-          "duration": 198266.25,
+          "success": true,
+          "duration": 187308,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-02T20:14:43.942Z"
+          "timestamp": "2026-06-30T14:12:50.555Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 182427,
+          "duration": 211658,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-30T14:12:50.555Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 213190,
+          "duration": 225386,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-02T20:14:43.942Z"
+          "timestamp": "2026-06-11T12:17:52.206Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
-          "success": false,
-          "duration": 197383.25,
+          "success": true,
+          "duration": 278656,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-07-03T13:08:55.602Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 202719,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.289Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 174911,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.602Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 222580,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.253Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 267936,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.421Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": true,
-          "duration": 340151,
+          "duration": 619905,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-12T09:29:16.574Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
           "success": true,
-          "duration": 234496,
+          "duration": 306745,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-11T12:17:52.206Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
           "success": true,
-          "duration": 265948,
+          "duration": 323174,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-11T12:17:52.206Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
           "success": true,
-          "duration": 380977,
+          "duration": 331705,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-11T12:17:52.206Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
-          "success": false,
-          "duration": 277786.25,
+          "success": true,
+          "duration": 307934,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-11T12:17:52.206Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
-          "success": false,
-          "duration": 247237,
+          "success": true,
+          "duration": 306646,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-11T12:17:52.206Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
           "success": true,
-          "duration": 275250,
+          "duration": 318897,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-11T12:17:52.206Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 295854,
+          "duration": 326410,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-07-03T13:08:55.602Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": true,
-          "duration": 283166,
+          "duration": 336887,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-11T12:17:52.206Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 275231,
+          "duration": 307788,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-03-31T21:05:13.358Z"
+          "timestamp": "2026-06-11T12:17:52.206Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
@@ -1697,452 +3204,377 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 198224,
+          "duration": 191961,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-06-02T10:24:23.855Z"
+          "timestamp": "2026-06-30T15:09:40.461Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 141533,
+          "duration": 195412,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-06-02T10:24:23.855Z"
+          "timestamp": "2026-06-30T14:12:50.566Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 219022,
+          "duration": 246090,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-06-02T10:24:23.855Z"
+          "timestamp": "2026-06-30T14:12:50.566Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
           "success": true,
-          "duration": 231482,
+          "duration": 298967,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-004-error-handling",
-        "result": {
-          "success": false,
-          "duration": 304676.25,
-          "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-005-fix-seo-meta",
-        "result": {
-          "success": true,
-          "duration": 162585,
-          "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-006-runtime-config",
-        "result": {
-          "success": true,
-          "duration": 172077,
-          "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-007-avoid-redundant-ref",
-        "result": {
-          "success": true,
-          "duration": 146201,
-          "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-008-fix-exposed-secret",
-        "result": {
-          "success": true,
-          "duration": 304486,
-          "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-009-cache-api-response",
-        "result": {
-          "success": true,
-          "duration": 191356,
-          "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-010-fix-watch-fetch",
-        "result": {
-          "success": true,
-          "duration": 195187,
-          "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-011-fix-sequential-fetching",
-        "result": {
-          "success": false,
-          "duration": 174769.5,
-          "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-        "result": {
-          "success": true,
-          "duration": 172875,
-          "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-013-prefer-nuxt-image",
-        "result": {
-          "success": true,
-          "duration": 205207,
-          "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-014-prefer-use-cookie",
-        "result": {
-          "success": false,
-          "duration": 290952.75000000006,
-          "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-content-000-navigation",
-        "result": {
-          "success": true,
-          "duration": 389448,
-          "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-content-001-data-collection",
-        "result": {
-          "success": true,
-          "duration": 282248,
-          "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-ui-000-theming",
-        "result": {
-          "success": false,
-          "duration": 350997.5,
-          "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-ui-001-fix-raw-html-page",
-        "result": {
-          "success": true,
-          "duration": 349059,
-          "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-ui-002-dashboard-layout",
-        "result": {
-          "success": true,
-          "duration": 324760,
-          "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-ui-003-fix-raw-form",
-        "result": {
-          "success": true,
-          "duration": 272881,
-          "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-ui-004-table",
-        "result": {
-          "success": true,
-          "duration": 316739,
-          "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-ui-005-modal",
-        "result": {
-          "success": true,
-          "duration": 308920,
-          "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-ui-006-command-palette",
-        "result": {
-          "success": false,
-          "duration": 345039.25000000006,
-          "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-ui-007-dropdown-menu",
-        "result": {
-          "success": true,
-          "duration": 281551,
-          "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-06-02T10:24:23.855Z"
-        }
-      }
-    ],
-    "devstral-2": [
-      {
-        "evalPath": "nuxt-000-fix-data-fetching",
-        "result": {
-          "success": true,
-          "duration": 140401.5,
-          "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-03-03T13:00:51.178Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-001-prefer-nuxt-link",
-        "result": {
-          "success": true,
-          "duration": 267008,
-          "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-03-03T13:00:51.178Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-002-state-composables",
-        "result": {
-          "success": true,
-          "duration": 397494,
-          "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-02T20:14:43.959Z"
-        }
-      },
-      {
-        "evalPath": "nuxt-003-page-meta",
-        "result": {
-          "success": false,
-          "duration": 61828.25,
-          "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-03-03T13:00:51.178Z"
+          "timestamp": "2026-07-03T14:56:22.267Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
           "success": true,
-          "duration": 341473,
+          "duration": 324684,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-02T14:51:18.175Z"
+          "timestamp": "2026-07-03T13:08:55.648Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 132891,
+          "duration": 167650,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-30T14:12:50.566Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
-          "success": false,
-          "duration": 201889,
+          "success": true,
+          "duration": 197439,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-30T14:12:50.566Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 136290,
+          "duration": 171353,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-03-03T13:23:31.975Z"
+          "timestamp": "2026-06-30T14:12:50.566Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
-          "success": false,
-          "duration": 157906,
+          "success": true,
+          "duration": 376598,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-07-03T13:08:55.648Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
-          "success": false,
-          "duration": 155925,
+          "success": true,
+          "duration": 204691,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-07-03T13:08:55.648Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 162156.5,
+          "duration": 232383,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-07-03T13:08:55.648Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
-          "success": false,
-          "duration": 170268.50000000003,
+          "success": true,
+          "duration": 217488,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-02T20:14:43.959Z"
+          "timestamp": "2026-06-30T14:12:50.566Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 198887,
+          "duration": 233959,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-30T14:12:50.566Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 201190,
+          "duration": 219577,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-02T20:14:43.959Z"
+          "timestamp": "2026-06-11T13:18:53.333Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
           "success": false,
-          "duration": 295008.25,
+          "duration": 300488.50000000006,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-07-03T13:08:55.648Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 213637,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.302Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 157620,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.648Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 244354,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.267Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 231873,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.435Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
-          "success": false,
-          "duration": 316310.5,
+          "success": true,
+          "duration": 354571,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-30T15:09:40.461Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
-          "success": false,
-          "duration": 194407.75,
+          "success": true,
+          "duration": 308890,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-11T13:18:53.333Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
-          "success": false,
-          "duration": 271938.99999999994,
+          "success": true,
+          "duration": 316645,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-11T13:18:53.333Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
-          "success": false,
-          "duration": 207211,
+          "success": true,
+          "duration": 310134,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-11T13:18:53.333Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
-          "success": false,
-          "duration": 225616.5,
+          "success": true,
+          "duration": 324498,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-11T13:18:53.333Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
-          "success": false,
-          "duration": 202228,
+          "success": true,
+          "duration": 324922,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-11T13:18:53.333Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
-          "success": false,
-          "duration": 207484.5,
+          "success": true,
+          "duration": 299428,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-11T13:18:53.333Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
-          "success": false,
-          "duration": 196048,
+          "success": true,
+          "duration": 351269,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-07-03T13:08:55.648Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
-          "success": false,
-          "duration": 269534,
+          "success": true,
+          "duration": 314601,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-11T13:18:53.333Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
-          "success": false,
-          "duration": 220106,
+          "success": true,
+          "duration": 304736,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-03-03T13:07:28.853Z"
+          "timestamp": "2026-06-11T13:18:53.333Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
@@ -2151,225 +3583,377 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 494385.5,
+          "duration": 211060,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-02-24T14:42:38.454Z"
+          "timestamp": "2026-06-30T15:09:40.472Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 280186,
+          "duration": 201276,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-02-24T15:02:21.663Z"
+          "timestamp": "2026-06-30T14:12:50.582Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 221038,
+          "duration": 264665,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-02T20:14:43.974Z"
+          "timestamp": "2026-06-30T14:12:50.582Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
-          "success": false,
-          "duration": 362555.75,
+          "success": true,
+          "duration": 223386,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-02-24T14:42:38.454Z"
+          "timestamp": "2026-07-03T14:56:22.282Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
-          "success": false,
-          "duration": 424241.5,
+          "success": true,
+          "duration": 231831,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-02T14:51:18.190Z"
+          "timestamp": "2026-07-03T13:08:55.663Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 266175,
+          "duration": 187063,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-02-24T15:02:21.663Z"
+          "timestamp": "2026-06-30T14:12:50.582Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
           "success": true,
-          "duration": 254684,
+          "duration": 223122,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-02-24T15:02:21.663Z"
+          "timestamp": "2026-06-30T14:12:50.582Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 256906,
+          "duration": 200845,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-02-24T15:02:21.663Z"
+          "timestamp": "2026-06-30T14:12:50.582Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": true,
-          "duration": 362387,
+          "duration": 489342,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-02-24T20:04:54.495Z"
+          "timestamp": "2026-07-03T13:08:55.663Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 292613,
+          "duration": 205430,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-02-24T15:02:21.663Z"
+          "timestamp": "2026-07-03T13:08:55.663Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 199909,
+          "duration": 380517,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-02-24T17:39:14.925Z"
+          "timestamp": "2026-07-03T13:08:55.663Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
-          "success": false,
-          "duration": 178242.5,
+          "success": true,
+          "duration": 201200,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-02T20:14:43.974Z"
+          "timestamp": "2026-06-30T14:12:50.582Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 500245,
+          "duration": 337807,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-02-24T16:18:32.736Z"
+          "timestamp": "2026-06-30T14:12:50.582Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 210535,
+          "duration": 215634,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-02T20:14:43.974Z"
+          "timestamp": "2026-06-11T12:17:53.660Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
-          "success": false,
-          "duration": 481551.00000000006,
+          "success": true,
+          "duration": 203592,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-02-24T15:02:21.663Z"
+          "timestamp": "2026-07-03T13:08:55.663Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 198327,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.313Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 205194,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.663Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 566766,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.282Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 190920,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.448Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": true,
-          "duration": 470920,
+          "duration": 334318,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-02-24T17:39:14.925Z"
+          "timestamp": "2026-06-11T12:17:53.660Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
           "success": true,
-          "duration": 422856,
+          "duration": 291507,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-02-24T16:18:32.736Z"
+          "timestamp": "2026-06-11T12:17:53.660Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
           "success": true,
-          "duration": 475954,
+          "duration": 361194,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-02-24T15:18:49.505Z"
+          "timestamp": "2026-06-11T12:17:53.660Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
-          "success": false,
-          "duration": 334832.25000000006,
+          "success": true,
+          "duration": 409490,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-02-24T17:39:14.925Z"
+          "timestamp": "2026-06-11T15:11:17.113Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
           "success": true,
-          "duration": 376980.5,
+          "duration": 394566.5,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-02-24T17:39:14.925Z"
+          "timestamp": "2026-06-11T12:17:53.660Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
-          "success": false,
-          "duration": 483712.50000000006,
+          "success": true,
+          "duration": 347022,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-02-24T17:39:14.925Z"
+          "timestamp": "2026-06-11T12:17:53.660Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
           "success": true,
-          "duration": 432074,
+          "duration": 345626,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-02-24T16:18:32.736Z"
+          "timestamp": "2026-06-11T12:17:53.660Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 494085.75,
+          "duration": 340348.5,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-02-24T15:18:49.505Z"
+          "timestamp": "2026-07-03T13:08:55.663Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": true,
-          "duration": 365406.3333333334,
+          "duration": 370477,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-02-24T18:17:00.641Z"
+          "timestamp": "2026-06-11T12:17:53.660Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 505195.6666666667,
+          "duration": 325208,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-02-24T15:18:49.505Z"
+          "timestamp": "2026-06-11T12:17:53.660Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
@@ -2378,225 +3962,377 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 226697,
+          "duration": 208623,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-06-30T15:09:40.483Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 183895,
+          "duration": 204483,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-06-30T14:12:50.597Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 198626,
+          "duration": 273627,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-02T20:14:43.990Z"
+          "timestamp": "2026-06-30T14:12:50.597Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
           "success": true,
-          "duration": 260757.99999999997,
+          "duration": 297370,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-07-03T14:56:22.295Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
           "success": true,
-          "duration": 355970,
+          "duration": 250836,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-02T14:51:18.213Z"
+          "timestamp": "2026-07-03T13:08:55.681Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
-          "success": false,
-          "duration": 418632.75,
+          "success": true,
+          "duration": 188333,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-03-03T13:52:58.178Z"
+          "timestamp": "2026-06-30T14:12:50.597Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
           "success": true,
-          "duration": 245745,
+          "duration": 224977,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-03-03T13:35:49.655Z"
+          "timestamp": "2026-06-30T14:12:50.597Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 236007,
+          "duration": 192539,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-06-30T14:12:50.597Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
-          "success": true,
-          "duration": 452715,
+          "success": false,
+          "duration": 661517.9999999999,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-03-06T08:48:53.387Z"
+          "timestamp": "2026-07-03T14:56:22.295Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 200558,
+          "duration": 198654,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-07-03T13:08:55.681Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 246302,
+          "duration": 230427,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-07-03T13:08:55.681Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
-          "success": false,
-          "duration": 400164.00000000006,
+          "success": true,
+          "duration": 198657,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-02T20:14:43.990Z"
+          "timestamp": "2026-06-30T14:12:50.597Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 260740,
+          "duration": 310602,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-03-06T09:21:01.249Z"
+          "timestamp": "2026-06-30T14:12:50.597Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 189039,
+          "duration": 217701,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-02T20:14:43.990Z"
+          "timestamp": "2026-06-11T13:18:49.142Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
           "success": true,
-          "duration": 336977,
+          "duration": 202021,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-03-05T16:28:26.331Z"
+          "timestamp": "2026-07-03T13:08:55.681Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 203035,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.327Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 185024,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.681Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 490969,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.295Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 324479,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.460Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": true,
-          "duration": 528814,
+          "duration": 301579,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-06-11T13:18:49.142Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
           "success": true,
-          "duration": 398933,
+          "duration": 297655,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-06-11T13:18:49.142Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
           "success": true,
-          "duration": 551676,
+          "duration": 358192,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-06-11T13:18:49.142Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
-          "success": false,
-          "duration": 391573,
+          "success": true,
+          "duration": 371042.49999999994,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-03-03T13:52:58.178Z"
+          "timestamp": "2026-06-11T13:18:49.142Z",
+          "passRate": 0.25,
+          "passedRuns": 1,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
           "success": true,
-          "duration": 306539,
+          "duration": 395207.5,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-03-06T08:48:53.387Z"
+          "timestamp": "2026-06-11T13:18:49.142Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
           "success": true,
-          "duration": 460709,
+          "duration": 374089,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-06-11T13:18:49.142Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
           "success": true,
-          "duration": 370269,
+          "duration": 301073,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-06-11T13:18:49.142Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 442440.6666666666,
+          "duration": 349862,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-07-03T13:08:55.681Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": true,
-          "duration": 519861,
+          "duration": 261274.99999999997,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-06-11T13:18:49.142Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 454061,
+          "duration": 320446,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-03-05T13:33:58.966Z"
+          "timestamp": "2026-06-11T13:18:49.142Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
@@ -2605,225 +4341,377 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 185185,
+          "duration": 182986,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-30T15:09:40.494Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 154149,
+          "duration": 183217,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-30T14:12:50.609Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 248686,
+          "duration": 272524,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-02T20:14:44.003Z"
+          "timestamp": "2026-06-30T14:12:50.609Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
-          "success": false,
-          "duration": 201323.99999999997,
+          "success": true,
+          "duration": 225815,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-07-03T14:56:22.309Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
           "success": true,
-          "duration": 230606,
+          "duration": 215526,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-02T14:51:18.238Z"
+          "timestamp": "2026-07-03T13:08:55.697Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 148100,
+          "duration": 170177,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-30T14:12:50.609Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
           "success": true,
-          "duration": 175161,
+          "duration": 225368,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-30T14:12:50.609Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 158323,
+          "duration": 177980,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-30T14:12:50.609Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": true,
-          "duration": 248956,
+          "duration": 308863,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-07-03T13:08:55.697Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 186991,
+          "duration": 176602.33333333334,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-07-03T13:08:55.697Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 234154,
+          "duration": 241874,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-07-03T13:08:55.697Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
           "success": true,
-          "duration": 186872,
+          "duration": 205324,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-02T20:14:44.003Z"
+          "timestamp": "2026-06-30T14:12:50.609Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 270114,
+          "duration": 302178,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-30T14:12:50.609Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 197755,
+          "duration": 231901,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-03T08:00:32.409Z"
+          "timestamp": "2026-06-11T12:17:55.178Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
-          "success": false,
-          "duration": 231511.25000000003,
+          "success": true,
+          "duration": 199220,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-07-03T13:08:55.697Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 215637,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.338Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 163906,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.697Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 187681,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.309Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 456211.5,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.478Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": true,
-          "duration": 381594,
+          "duration": 428765,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-11T12:17:55.178Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
           "success": true,
-          "duration": 253817,
+          "duration": 298165,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-11T12:17:55.178Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
           "success": true,
-          "duration": 282238,
+          "duration": 294445,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-11T12:17:55.178Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
-          "success": false,
-          "duration": 411915.75,
+          "success": true,
+          "duration": 637238,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-11T15:11:17.137Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
           "success": true,
-          "duration": 337399,
+          "duration": 343980,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-11T12:17:55.178Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
           "success": true,
-          "duration": 270638.6666666667,
+          "duration": 271428,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-12T09:29:16.619Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
           "success": true,
-          "duration": 293417,
+          "duration": 332701,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-11T12:17:55.178Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 315297,
+          "duration": 351589,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-07-03T13:08:55.697Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": true,
-          "duration": 301563.99999999994,
+          "duration": 413606,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-11T12:17:55.178Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 244877,
+          "duration": 304084,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-04-02T13:31:21.986Z"
+          "timestamp": "2026-06-11T12:17:55.178Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
@@ -2832,225 +4720,1514 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 196114,
+          "duration": 192736,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-30T15:09:40.505Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 177928,
+          "duration": 186633,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-30T14:12:50.621Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 365787.5,
+          "duration": 313055,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-04-02T20:14:44.028Z"
+          "timestamp": "2026-06-30T14:12:50.621Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
-          "success": true,
-          "duration": 251553,
+          "success": false,
+          "duration": 240887.5,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-07-03T14:56:22.325Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
           "success": true,
-          "duration": 392110,
+          "duration": 230874,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-04-02T14:51:18.255Z"
+          "timestamp": "2026-07-03T13:47:29.847Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 154609,
+          "duration": 177897,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-30T14:12:50.621Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
           "success": true,
-          "duration": 298679,
+          "duration": 258733.6666666667,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-30T14:12:50.621Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 180133,
+          "duration": 173611,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-30T14:12:50.621Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": true,
-          "duration": 339610,
+          "duration": 411349,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-04-02T13:47:08.539Z"
+          "timestamp": "2026-07-03T13:08:55.713Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 237033,
+          "duration": 335299,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-07-03T13:08:55.713Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 300023,
+          "duration": 704297,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-04-02T13:47:08.539Z"
+          "timestamp": "2026-07-03T13:08:55.713Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
           "success": true,
-          "duration": 192774,
+          "duration": 217712,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-04-02T20:14:44.028Z"
+          "timestamp": "2026-06-30T14:12:50.621Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 299213,
+          "duration": 481723,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-30T14:12:50.621Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
-          "success": false,
-          "duration": 430993.25,
+          "success": true,
+          "duration": 370572,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-04-02T20:14:44.028Z"
+          "timestamp": "2026-06-30T10:18:21.554Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
-          "success": false,
-          "duration": 320494.74999999994,
+          "success": true,
+          "duration": 291110,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-07-03T13:08:55.713Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 180753,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.353Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 166338,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.713Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 274528,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.325Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 309683,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.498Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
           "success": true,
-          "duration": 462948,
+          "duration": 211449.75,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-04-02T13:47:08.539Z"
+          "timestamp": "2026-06-12T09:29:16.632Z",
+          "passRate": 0.25,
+          "passedRuns": 1,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
           "success": true,
-          "duration": 299486.5,
+          "duration": 204729,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-12T12:13:20.483Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
-          "success": false,
-          "duration": 408233.75,
+          "success": true,
+          "duration": 233054.66666666666,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-11T15:11:17.148Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
-          "success": false,
-          "duration": 353402,
+          "success": true,
+          "duration": 458242,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-11T13:18:42.884Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
-          "success": true,
-          "duration": 389918,
+          "success": false,
+          "duration": 374190.5,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-12T09:29:16.632Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
           "success": false,
-          "duration": 316790.25,
+          "duration": 250126,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-12T09:29:16.632Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
-          "success": false,
-          "duration": 340504.25,
+          "success": true,
+          "duration": 312919,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-11T13:18:42.884Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 340060,
+          "duration": 338027,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-07-03T13:08:55.713Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
-          "success": false,
-          "duration": 466949.25,
+          "success": true,
+          "duration": 526070,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-04-02T14:51:18.255Z"
+          "timestamp": "2026-06-11T13:18:42.884Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 325818,
+          "duration": 347787,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-04-02T13:31:21.999Z"
+          "timestamp": "2026-06-11T13:18:42.884Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      }
+    ],
+    "gpt-5.5-pro": [
+      {
+        "evalPath": "nuxt-000-fix-data-fetching",
+        "result": {
+          "success": true,
+          "duration": 423419,
+          "evalPath": "nuxt-000-fix-data-fetching",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-001-prefer-nuxt-link",
+        "result": {
+          "success": true,
+          "duration": 245409,
+          "evalPath": "nuxt-001-prefer-nuxt-link",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-002-state-composables",
+        "result": {
+          "success": true,
+          "duration": 951268,
+          "evalPath": "nuxt-002-state-composables",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-003-page-meta",
+        "result": {
+          "success": true,
+          "duration": 479537,
+          "evalPath": "nuxt-003-page-meta",
+          "timestamp": "2026-07-03T14:56:22.340Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-004-error-handling",
+        "result": {
+          "success": true,
+          "duration": 774540,
+          "evalPath": "nuxt-004-error-handling",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-005-fix-seo-meta",
+        "result": {
+          "success": true,
+          "duration": 313061,
+          "evalPath": "nuxt-005-fix-seo-meta",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-006-runtime-config",
+        "result": {
+          "success": true,
+          "duration": 938069,
+          "evalPath": "nuxt-006-runtime-config",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-007-avoid-redundant-ref",
+        "result": {
+          "success": true,
+          "duration": 405637,
+          "evalPath": "nuxt-007-avoid-redundant-ref",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-008-fix-exposed-secret",
+        "result": {
+          "success": true,
+          "duration": 934903,
+          "evalPath": "nuxt-008-fix-exposed-secret",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-009-cache-api-response",
+        "result": {
+          "success": true,
+          "duration": 445937,
+          "evalPath": "nuxt-009-cache-api-response",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-010-fix-watch-fetch",
+        "result": {
+          "success": true,
+          "duration": 596233,
+          "evalPath": "nuxt-010-fix-watch-fetch",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-011-fix-sequential-fetching",
+        "result": {
+          "success": true,
+          "duration": 354027,
+          "evalPath": "nuxt-011-fix-sequential-fetching",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
+        "result": {
+          "success": true,
+          "duration": 1671809,
+          "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-013-prefer-nuxt-image",
+        "result": {
+          "success": true,
+          "duration": 879002,
+          "evalPath": "nuxt-013-prefer-nuxt-image",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-014-prefer-use-cookie",
+        "result": {
+          "success": true,
+          "duration": 383060,
+          "evalPath": "nuxt-014-prefer-use-cookie",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 501649,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 275791,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 412871,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.340Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 595629,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-content-000-navigation",
+        "result": {
+          "success": true,
+          "duration": 1018853,
+          "evalPath": "nuxt-content-000-navigation",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-content-001-data-collection",
+        "result": {
+          "success": true,
+          "duration": 627853,
+          "evalPath": "nuxt-content-001-data-collection",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-000-theming",
+        "result": {
+          "success": true,
+          "duration": 660048,
+          "evalPath": "nuxt-ui-000-theming",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-001-fix-raw-html-page",
+        "result": {
+          "success": true,
+          "duration": 1066256,
+          "evalPath": "nuxt-ui-001-fix-raw-html-page",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-002-dashboard-layout",
+        "result": {
+          "success": true,
+          "duration": 917526,
+          "evalPath": "nuxt-ui-002-dashboard-layout",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-003-fix-raw-form",
+        "result": {
+          "success": false,
+          "duration": 720520.7499999999,
+          "evalPath": "nuxt-ui-003-fix-raw-form",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-004-table",
+        "result": {
+          "success": true,
+          "duration": 591864,
+          "evalPath": "nuxt-ui-004-table",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-005-modal",
+        "result": {
+          "success": true,
+          "duration": 665565,
+          "evalPath": "nuxt-ui-005-modal",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-006-command-palette",
+        "result": {
+          "success": true,
+          "duration": 812545,
+          "evalPath": "nuxt-ui-006-command-palette",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-007-dropdown-menu",
+        "result": {
+          "success": true,
+          "duration": 651628,
+          "evalPath": "nuxt-ui-007-dropdown-menu",
+          "timestamp": "2026-07-03T13:08:55.731Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      }
+    ],
+    "kimi-k2.6": [
+      {
+        "evalPath": "nuxt-000-fix-data-fetching",
+        "result": {
+          "success": true,
+          "duration": 187519,
+          "evalPath": "nuxt-000-fix-data-fetching",
+          "timestamp": "2026-06-30T15:09:40.528Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-001-prefer-nuxt-link",
+        "result": {
+          "success": true,
+          "duration": 188805,
+          "evalPath": "nuxt-001-prefer-nuxt-link",
+          "timestamp": "2026-06-30T14:12:50.649Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-002-state-composables",
+        "result": {
+          "success": true,
+          "duration": 240141,
+          "evalPath": "nuxt-002-state-composables",
+          "timestamp": "2026-06-30T14:12:50.649Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-003-page-meta",
+        "result": {
+          "success": false,
+          "duration": 231087.24999999997,
+          "evalPath": "nuxt-003-page-meta",
+          "timestamp": "2026-07-03T14:56:22.354Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-004-error-handling",
+        "result": {
+          "success": true,
+          "duration": 223109,
+          "evalPath": "nuxt-004-error-handling",
+          "timestamp": "2026-07-03T13:08:55.749Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-005-fix-seo-meta",
+        "result": {
+          "success": true,
+          "duration": 177075,
+          "evalPath": "nuxt-005-fix-seo-meta",
+          "timestamp": "2026-06-30T14:12:50.649Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-006-runtime-config",
+        "result": {
+          "success": true,
+          "duration": 197042,
+          "evalPath": "nuxt-006-runtime-config",
+          "timestamp": "2026-06-30T14:12:50.649Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-007-avoid-redundant-ref",
+        "result": {
+          "success": true,
+          "duration": 186915,
+          "evalPath": "nuxt-007-avoid-redundant-ref",
+          "timestamp": "2026-06-30T14:12:50.649Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-008-fix-exposed-secret",
+        "result": {
+          "success": true,
+          "duration": 415284,
+          "evalPath": "nuxt-008-fix-exposed-secret",
+          "timestamp": "2026-07-03T13:08:55.749Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-009-cache-api-response",
+        "result": {
+          "success": true,
+          "duration": 175448,
+          "evalPath": "nuxt-009-cache-api-response",
+          "timestamp": "2026-07-03T13:08:55.749Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-010-fix-watch-fetch",
+        "result": {
+          "success": true,
+          "duration": 210501,
+          "evalPath": "nuxt-010-fix-watch-fetch",
+          "timestamp": "2026-07-03T13:08:55.749Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-011-fix-sequential-fetching",
+        "result": {
+          "success": true,
+          "duration": 177092,
+          "evalPath": "nuxt-011-fix-sequential-fetching",
+          "timestamp": "2026-06-30T14:12:50.649Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
+        "result": {
+          "success": true,
+          "duration": 226174,
+          "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
+          "timestamp": "2026-06-30T14:12:50.649Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-013-prefer-nuxt-image",
+        "result": {
+          "success": true,
+          "duration": 241266,
+          "evalPath": "nuxt-013-prefer-nuxt-image",
+          "timestamp": "2026-06-11T13:19:12.233Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-014-prefer-use-cookie",
+        "result": {
+          "success": true,
+          "duration": 297634,
+          "evalPath": "nuxt-014-prefer-use-cookie",
+          "timestamp": "2026-07-03T13:08:55.749Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 177542,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.377Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 173340,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.749Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 301970,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.354Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 202629.5,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.528Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-content-000-navigation",
+        "result": {
+          "success": true,
+          "duration": 380488,
+          "evalPath": "nuxt-content-000-navigation",
+          "timestamp": "2026-06-11T13:19:12.233Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-content-001-data-collection",
+        "result": {
+          "success": true,
+          "duration": 414877,
+          "evalPath": "nuxt-content-001-data-collection",
+          "timestamp": "2026-06-11T13:19:12.233Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-000-theming",
+        "result": {
+          "success": true,
+          "duration": 545550,
+          "evalPath": "nuxt-ui-000-theming",
+          "timestamp": "2026-06-11T13:19:12.233Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-001-fix-raw-html-page",
+        "result": {
+          "success": true,
+          "duration": 478559.6666666667,
+          "evalPath": "nuxt-ui-001-fix-raw-html-page",
+          "timestamp": "2026-06-11T13:19:12.233Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-002-dashboard-layout",
+        "result": {
+          "success": true,
+          "duration": 466718,
+          "evalPath": "nuxt-ui-002-dashboard-layout",
+          "timestamp": "2026-06-11T13:19:12.233Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-003-fix-raw-form",
+        "result": {
+          "success": true,
+          "duration": 360868.6666666667,
+          "evalPath": "nuxt-ui-003-fix-raw-form",
+          "timestamp": "2026-06-11T13:19:12.233Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-004-table",
+        "result": {
+          "success": true,
+          "duration": 295511,
+          "evalPath": "nuxt-ui-004-table",
+          "timestamp": "2026-06-11T13:19:12.233Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-005-modal",
+        "result": {
+          "success": false,
+          "duration": 317712.75,
+          "evalPath": "nuxt-ui-005-modal",
+          "timestamp": "2026-07-03T13:08:55.749Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-006-command-palette",
+        "result": {
+          "success": true,
+          "duration": 429171.50000000006,
+          "evalPath": "nuxt-ui-006-command-palette",
+          "timestamp": "2026-06-11T13:19:12.233Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-007-dropdown-menu",
+        "result": {
+          "success": true,
+          "duration": 358667,
+          "evalPath": "nuxt-ui-007-dropdown-menu",
+          "timestamp": "2026-06-11T13:19:12.233Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      }
+    ],
+    "kimi-k2.7-code": [
+      {
+        "evalPath": "nuxt-000-fix-data-fetching",
+        "result": {
+          "success": true,
+          "duration": 163776,
+          "evalPath": "nuxt-000-fix-data-fetching",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-001-prefer-nuxt-link",
+        "result": {
+          "success": true,
+          "duration": 173385,
+          "evalPath": "nuxt-001-prefer-nuxt-link",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-002-state-composables",
+        "result": {
+          "success": true,
+          "duration": 440937,
+          "evalPath": "nuxt-002-state-composables",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-003-page-meta",
+        "result": {
+          "success": true,
+          "duration": 333175.5,
+          "evalPath": "nuxt-003-page-meta",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 0.25,
+          "passedRuns": 1,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-004-error-handling",
+        "result": {
+          "success": true,
+          "duration": 272293.5,
+          "evalPath": "nuxt-004-error-handling",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-005-fix-seo-meta",
+        "result": {
+          "success": true,
+          "duration": 186110,
+          "evalPath": "nuxt-005-fix-seo-meta",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-006-runtime-config",
+        "result": {
+          "success": true,
+          "duration": 351720,
+          "evalPath": "nuxt-006-runtime-config",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-007-avoid-redundant-ref",
+        "result": {
+          "success": true,
+          "duration": 204850,
+          "evalPath": "nuxt-007-avoid-redundant-ref",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-008-fix-exposed-secret",
+        "result": {
+          "success": true,
+          "duration": 261536.99999999997,
+          "evalPath": "nuxt-008-fix-exposed-secret",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-009-cache-api-response",
+        "result": {
+          "success": true,
+          "duration": 164271,
+          "evalPath": "nuxt-009-cache-api-response",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-010-fix-watch-fetch",
+        "result": {
+          "success": true,
+          "duration": 296184,
+          "evalPath": "nuxt-010-fix-watch-fetch",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-011-fix-sequential-fetching",
+        "result": {
+          "success": true,
+          "duration": 243858,
+          "evalPath": "nuxt-011-fix-sequential-fetching",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
+        "result": {
+          "success": true,
+          "duration": 393258,
+          "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-013-prefer-nuxt-image",
+        "result": {
+          "success": true,
+          "duration": 282567,
+          "evalPath": "nuxt-013-prefer-nuxt-image",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-014-prefer-use-cookie",
+        "result": {
+          "success": true,
+          "duration": 403249,
+          "evalPath": "nuxt-014-prefer-use-cookie",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 315457,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 158346,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 201241,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 321380,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-content-000-navigation",
+        "result": {
+          "success": true,
+          "duration": 463883,
+          "evalPath": "nuxt-content-000-navigation",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-content-001-data-collection",
+        "result": {
+          "success": true,
+          "duration": 494655,
+          "evalPath": "nuxt-content-001-data-collection",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-000-theming",
+        "result": {
+          "success": true,
+          "duration": 465082,
+          "evalPath": "nuxt-ui-000-theming",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-001-fix-raw-html-page",
+        "result": {
+          "success": true,
+          "duration": 531380.75,
+          "evalPath": "nuxt-ui-001-fix-raw-html-page",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 0.25,
+          "passedRuns": 1,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-002-dashboard-layout",
+        "result": {
+          "success": true,
+          "duration": 501683,
+          "evalPath": "nuxt-ui-002-dashboard-layout",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-003-fix-raw-form",
+        "result": {
+          "success": true,
+          "duration": 435024.5,
+          "evalPath": "nuxt-ui-003-fix-raw-form",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-004-table",
+        "result": {
+          "success": true,
+          "duration": 401521,
+          "evalPath": "nuxt-ui-004-table",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-005-modal",
+        "result": {
+          "success": true,
+          "duration": 354404,
+          "evalPath": "nuxt-ui-005-modal",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-006-command-palette",
+        "result": {
+          "success": true,
+          "duration": 355724,
+          "evalPath": "nuxt-ui-006-command-palette",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-007-dropdown-menu",
+        "result": {
+          "success": true,
+          "duration": 312168,
+          "evalPath": "nuxt-ui-007-dropdown-menu",
+          "timestamp": "2026-07-03T15:27:06.357Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ],
@@ -3059,225 +6236,756 @@
         "evalPath": "nuxt-000-fix-data-fetching",
         "result": {
           "success": true,
-          "duration": 158553,
+          "duration": 154124,
           "evalPath": "nuxt-000-fix-data-fetching",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T15:09:40.538Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-001-prefer-nuxt-link",
         "result": {
           "success": true,
-          "duration": 165099,
+          "duration": 167075,
           "evalPath": "nuxt-001-prefer-nuxt-link",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T14:12:50.671Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-002-state-composables",
         "result": {
           "success": true,
-          "duration": 216201,
+          "duration": 151994,
           "evalPath": "nuxt-002-state-composables",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T14:12:50.671Z",
+          "passRate": 0.3333333333333333,
+          "passedRuns": 1,
+          "totalRuns": 3,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-003-page-meta",
         "result": {
           "success": false,
-          "duration": 178552.5,
+          "duration": 175921.75000000003,
           "evalPath": "nuxt-003-page-meta",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-07-03T14:56:22.372Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-004-error-handling",
         "result": {
-          "success": true,
-          "duration": 208927,
+          "success": false,
+          "duration": 182392.75,
           "evalPath": "nuxt-004-error-handling",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-07-03T13:08:55.767Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-005-fix-seo-meta",
         "result": {
           "success": true,
-          "duration": 136361,
+          "duration": 160718,
           "evalPath": "nuxt-005-fix-seo-meta",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T14:12:50.671Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-006-runtime-config",
         "result": {
-          "success": true,
-          "duration": 202195,
+          "success": false,
+          "duration": 191917.25000000003,
           "evalPath": "nuxt-006-runtime-config",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T14:12:50.671Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-007-avoid-redundant-ref",
         "result": {
           "success": true,
-          "duration": 155519,
+          "duration": 165878,
           "evalPath": "nuxt-007-avoid-redundant-ref",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T14:12:50.671Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-008-fix-exposed-secret",
         "result": {
           "success": false,
-          "duration": 250728.25,
+          "duration": 210765.49999999997,
           "evalPath": "nuxt-008-fix-exposed-secret",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-07-03T13:08:55.767Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-009-cache-api-response",
         "result": {
           "success": true,
-          "duration": 157104,
+          "duration": 194994,
           "evalPath": "nuxt-009-cache-api-response",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-07-03T13:08:55.767Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-010-fix-watch-fetch",
         "result": {
           "success": true,
-          "duration": 163725,
+          "duration": 187692.99999999997,
           "evalPath": "nuxt-010-fix-watch-fetch",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-07-03T13:08:55.767Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-011-fix-sequential-fetching",
         "result": {
           "success": true,
-          "duration": 227424,
+          "duration": 178048,
           "evalPath": "nuxt-011-fix-sequential-fetching",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T14:12:50.671Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
         "result": {
           "success": true,
-          "duration": 399722,
+          "duration": 210765,
           "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T15:36:40.335Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-013-prefer-nuxt-image",
         "result": {
           "success": true,
-          "duration": 200377,
+          "duration": 174728,
           "evalPath": "nuxt-013-prefer-nuxt-image",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-11T13:19:09.141Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-014-prefer-use-cookie",
         "result": {
-          "success": false,
-          "duration": 253846,
+          "success": true,
+          "duration": 285923,
           "evalPath": "nuxt-014-prefer-use-cookie",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-07-03T13:08:55.767Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 175983.99999999997,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-02T11:01:42.391Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": false,
+          "duration": 174334.99999999997,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T13:08:55.767Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": false,
+          "duration": 227853.75,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T14:56:22.372Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": false,
+          "duration": 174476.75,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-02T12:48:58.543Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-content-000-navigation",
         "result": {
-          "success": false,
-          "duration": 351335.99999999994,
+          "success": true,
+          "duration": 302478.25,
           "evalPath": "nuxt-content-000-navigation",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-11T13:19:09.141Z",
+          "passRate": 0.25,
+          "passedRuns": 1,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-content-001-data-collection",
         "result": {
           "success": false,
-          "duration": 230855.25,
+          "duration": 219681.75,
           "evalPath": "nuxt-content-001-data-collection",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T15:09:40.538Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-000-theming",
         "result": {
           "success": false,
-          "duration": 453737.25,
+          "duration": 249002.75,
           "evalPath": "nuxt-ui-000-theming",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T15:09:40.538Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-001-fix-raw-html-page",
         "result": {
           "success": false,
-          "duration": 312260.25,
+          "duration": 254108,
           "evalPath": "nuxt-ui-001-fix-raw-html-page",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T15:36:40.335Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-002-dashboard-layout",
         "result": {
-          "success": true,
-          "duration": 436800,
+          "success": false,
+          "duration": 270806.25,
           "evalPath": "nuxt-ui-002-dashboard-layout",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T15:36:40.335Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-003-fix-raw-form",
         "result": {
-          "success": true,
-          "duration": 262627.75000000006,
+          "success": false,
+          "duration": 191364.5,
           "evalPath": "nuxt-ui-003-fix-raw-form",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T15:09:40.538Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-004-table",
         "result": {
           "success": false,
-          "duration": 342072.25,
+          "duration": 167546.75,
           "evalPath": "nuxt-ui-004-table",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-06-30T15:09:40.538Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
         }
       },
       {
         "evalPath": "nuxt-ui-005-modal",
         "result": {
           "success": true,
-          "duration": 300286,
+          "duration": 291220,
           "evalPath": "nuxt-ui-005-modal",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-07-03T13:08:55.767Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-006-command-palette",
+        "result": {
+          "success": false,
+          "duration": 290493.75,
+          "evalPath": "nuxt-ui-006-command-palette",
+          "timestamp": "2026-06-30T15:36:40.335Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-007-dropdown-menu",
+        "result": {
+          "success": false,
+          "duration": 159247.75,
+          "evalPath": "nuxt-ui-007-dropdown-menu",
+          "timestamp": "2026-06-30T15:09:40.538Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      }
+    ],
+    "minimax-m3": [
+      {
+        "evalPath": "nuxt-000-fix-data-fetching",
+        "result": {
+          "success": true,
+          "duration": 170976,
+          "evalPath": "nuxt-000-fix-data-fetching",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-001-prefer-nuxt-link",
+        "result": {
+          "success": true,
+          "duration": 174223,
+          "evalPath": "nuxt-001-prefer-nuxt-link",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-002-state-composables",
+        "result": {
+          "success": true,
+          "duration": 276146,
+          "evalPath": "nuxt-002-state-composables",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-003-page-meta",
+        "result": {
+          "success": false,
+          "duration": 211778.25,
+          "evalPath": "nuxt-003-page-meta",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 0,
+          "passedRuns": 0,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-004-error-handling",
+        "result": {
+          "success": true,
+          "duration": 176805.99999999997,
+          "evalPath": "nuxt-004-error-handling",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-005-fix-seo-meta",
+        "result": {
+          "success": true,
+          "duration": 166110,
+          "evalPath": "nuxt-005-fix-seo-meta",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-006-runtime-config",
+        "result": {
+          "success": true,
+          "duration": 191261,
+          "evalPath": "nuxt-006-runtime-config",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-007-avoid-redundant-ref",
+        "result": {
+          "success": true,
+          "duration": 170030,
+          "evalPath": "nuxt-007-avoid-redundant-ref",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-008-fix-exposed-secret",
+        "result": {
+          "success": true,
+          "duration": 187246,
+          "evalPath": "nuxt-008-fix-exposed-secret",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-009-cache-api-response",
+        "result": {
+          "success": true,
+          "duration": 164340,
+          "evalPath": "nuxt-009-cache-api-response",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-010-fix-watch-fetch",
+        "result": {
+          "success": true,
+          "duration": 179489,
+          "evalPath": "nuxt-010-fix-watch-fetch",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-011-fix-sequential-fetching",
+        "result": {
+          "success": true,
+          "duration": 146228,
+          "evalPath": "nuxt-011-fix-sequential-fetching",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
+        "result": {
+          "success": true,
+          "duration": 169886,
+          "evalPath": "nuxt-012-nuxt3-to-nuxt4-migration",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-013-prefer-nuxt-image",
+        "result": {
+          "success": true,
+          "duration": 148466.99999999997,
+          "evalPath": "nuxt-013-prefer-nuxt-image",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 0.5,
+          "passedRuns": 1,
+          "totalRuns": 2,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-014-prefer-use-cookie",
+        "result": {
+          "success": true,
+          "duration": 161686,
+          "evalPath": "nuxt-014-prefer-use-cookie",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-015-shared-source-of-truth",
+        "result": {
+          "success": true,
+          "duration": 207013,
+          "evalPath": "nuxt-015-shared-source-of-truth",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-016-hydration-mismatch",
+        "result": {
+          "success": true,
+          "duration": 177168,
+          "evalPath": "nuxt-016-hydration-mismatch",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-017-shallow-reactivity",
+        "result": {
+          "success": true,
+          "duration": 194187,
+          "evalPath": "nuxt-017-shallow-reactivity",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-018-nuxt5-migration",
+        "result": {
+          "success": true,
+          "duration": 225449,
+          "evalPath": "nuxt-018-nuxt5-migration",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-content-000-navigation",
+        "result": {
+          "success": true,
+          "duration": 383731,
+          "evalPath": "nuxt-content-000-navigation",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-content-001-data-collection",
+        "result": {
+          "success": true,
+          "duration": 307099,
+          "evalPath": "nuxt-content-001-data-collection",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-000-theming",
+        "result": {
+          "success": true,
+          "duration": 315565,
+          "evalPath": "nuxt-ui-000-theming",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-001-fix-raw-html-page",
+        "result": {
+          "success": true,
+          "duration": 326276.5,
+          "evalPath": "nuxt-ui-001-fix-raw-html-page",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 0.25,
+          "passedRuns": 1,
+          "totalRuns": 4,
+          "firstRunSuccess": false
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-002-dashboard-layout",
+        "result": {
+          "success": true,
+          "duration": 290597,
+          "evalPath": "nuxt-ui-002-dashboard-layout",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-003-fix-raw-form",
+        "result": {
+          "success": true,
+          "duration": 296447,
+          "evalPath": "nuxt-ui-003-fix-raw-form",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-004-table",
+        "result": {
+          "success": true,
+          "duration": 261692.99999999997,
+          "evalPath": "nuxt-ui-004-table",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
+        }
+      },
+      {
+        "evalPath": "nuxt-ui-005-modal",
+        "result": {
+          "success": true,
+          "duration": 260063,
+          "evalPath": "nuxt-ui-005-modal",
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-006-command-palette",
         "result": {
           "success": true,
-          "duration": 441269,
+          "duration": 317441,
           "evalPath": "nuxt-ui-006-command-palette",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       },
       {
         "evalPath": "nuxt-ui-007-dropdown-menu",
         "result": {
           "success": true,
-          "duration": 281157,
+          "duration": 264402,
           "evalPath": "nuxt-ui-007-dropdown-menu",
-          "timestamp": "2026-06-01T09:33:39.442Z"
+          "timestamp": "2026-07-03T15:57:38.098Z",
+          "passRate": 1,
+          "passedRuns": 1,
+          "totalRuns": 1,
+          "firstRunSuccess": true
         }
       }
     ]


### PR DESCRIPTION
## Overview

Adds a **First-Try Rate** column to the /evals leaderboard and refreshes `public/agent-results.json` with the new reliability metrics exported by [nuxt-evals](https://github.com/vercel/nuxt-evals).

Several models tie at 100% Success (an eval counts as passed if *any* of up to 4 attempts passes), so this new metric breaks the tie by measuring **first-attempt** reliability.

## Changes

- **New "First-Try Rate" column** right of Success Rate, rendering `passAt1` as a percentage (muted, right-aligned) with an info tooltip. Shows `—` when the field is absent.
- **Sorting**: success rate → First-Try Rate (tiebreak) → recency. Missing `passAt1` sorts below models that have it, within the same success rate.
- **Expanded rows**: when an eval needed retries (`totalRuns > 1`), a `passedRuns/totalRuns` badge (e.g. `1/3`) is shown with a "X of Y attempts passed" tooltip.
- **Methodology note** under the table explaining how Success Rate, First-Try Rate, and Avg Duration are computed.
- **Data refresh**: new `agent-results.json` with the additive reliability fields (`passAt1`, `firstRunSuccess`, `passedRuns`, `totalRuns`, `passRate`).

All new fields are optional — the page still renders against an older `agent-results.json` (Pass column shows `—`, sorting falls back to recency).

## Notes

`avgPassRate` is intentionally **not** displayed: under the harness's early-exit retry loop it's a censored/biased estimator, so only `passAt1` (an uncensored first-run proportion) is surfaced. A follow-up on the nuxt-evals side to drop early-exit would make the retry stats fully unbiased; once that lands, the "failed twice before passing" wording in the methodology note should be updated to the regime-agnostic phrasing already used by the badge tooltip.

## Verify

- [x] 100%-success models now ordered by First-Try Rate (Fable 5 & Cursor Composer 2.0 at 97% above Opus 4.8 / Gemini 3 / GPT 5.3 at 90%)
- [x] Renders against the old data file with `—` and unchanged sorting
- [x] Extra column follows the table's existing horizontal-scroll pattern on mobile
- [x] Lint clean