### PR TITLE
fix(evals): prevent filter menus from overflowing on mobile

### DIFF
--- a/app/pages/evals.vue
+++ b/app/pages/evals.vue
@@ -356,7 +356,7 @@ const evalColumns: TableColumn<EvalResultItem>[] = [
 
     <UPageBody class="mt-0">
       <UContainer class="max-w-6xl">
-        <div class="flex items-center justify-between mb-4">
+        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
           <h2 class="text-2xl font-bold">
             Agent Performance Results
           </h2>
@@ -370,7 +370,7 @@ const evalColumns: TableColumn<EvalResultItem>[] = [
               color="neutral"
               variant="subtle"
               size="lg"
-              class="w-52 bg-elevated/50 hover:bg-elevated data-[state=open]:bg-elevated group"
+              class="flex-1 sm:flex-none sm:w-52 bg-elevated/50 hover:bg-elevated data-[state=open]:bg-elevated group"
               :ui="{
                 placeholder: 'text-highlighted',
                 trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200'
@@ -385,7 +385,7 @@ const evalColumns: TableColumn<EvalResultItem>[] = [
               color="neutral"
               variant="subtle"
               size="lg"
-              class="w-52 bg-elevated/50 hover:bg-elevated data-[state=open]:bg-elevated group"
+              class="flex-1 sm:flex-none sm:w-52 bg-elevated/50 hover:bg-elevated data-[state=open]:bg-elevated group"
               :ui="{
                 placeholder: 'text-highlighted',
                 trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200'


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I noticed this bug while browsing the evals page after seeing [this tweet](https://x.com/Atinux/status/2074789339817460176). :)

On mobile, the category and agent filter select menus overflow horizontally, causing a horizontal scroll on the whole page. This is because the header row forces the heading and two fixed-width (`w-52`) selects on a single line.

This PR stacks the heading above the filters below the `sm` breakpoint and lets the two selects share the available width (`flex-1`) on mobile, while keeping the exact same layout on desktop (`sm:w-52`).
