### PR TITLE
fix: fix navigation within docs aside

### DIFF
--- a/app/pages/docs/[...slug].vue
+++ b/app/pages/docs/[...slug].vue
@@ -20,7 +20,15 @@ const nuxtApp = useNuxtApp()
 const { version } = useDocsVersion()
 const { headerLinks } = useHeaderLinks()
 const { isAgentDocked } = useNuxtAgent()
-const path = computed(() => route.path.replace(/\/$/, ''))
+const path = ref(route.path.replace(/\/$/, ''))
+const pageKey = computed(() => kebabCase(path.value))
+const surroundKey = computed(() => `${pageKey.value}-surround`)
+
+onBeforeRouteUpdate((to) => {
+  if (to.path.startsWith('/docs/')) {
+    path.value = to.path.replace(/\/$/, '')
+  }
+})
 
 const ignoredPaths = ['.nuxt', '.output', '.env', 'node_modules']
 const navClass = (item: ContentNavigationItem) => {
@@ -52,12 +60,10 @@ function paintResponse() {
 }
 
 const [{ data: page, status }, { data: surround }] = await Promise.all([
-  useAsyncData(kebabCase(path.value), () => paintResponse().then(() => nuxtApp.static[kebabCase(path.value)] ?? queryCollection(version.value.collection).path(path.value).first()), {
-    watch: [path]
-  }),
-  useAsyncData(`${kebabCase(path.value)}-surround`, () => paintResponse().then(() => nuxtApp.static[`${kebabCase(path.value)}-surround`] ?? queryCollectionItemSurroundings(version.value.collection, path.value, {
+  useAsyncData(pageKey, () => paintResponse().then(() => nuxtApp.static[pageKey.value] ?? queryCollection(version.value.collection).path(path.value).first())),
+  useAsyncData(surroundKey, () => paintResponse().then(() => nuxtApp.static[surroundKey.value] ?? queryCollectionItemSurroundings(version.value.collection, path.value, {
     fields: ['description']
-  })), { watch: [path] })
+  })))
 ])
 
 watch(status, (status) => {
@@ -68,7 +74,7 @@ watch(status, (status) => {
   }
 })
 
-watch(route, () => {
+watch(path, () => {
   menuDrawerOpen.value = false
   onThisPageDrawerOpen.value = false
 })

--- a/test/browser/pages.spec.ts
+++ b/test/browser/pages.spec.ts
@@ -12,6 +12,22 @@ test.describe('Homepage', () => {
 })
 
 test.describe('Content Pages', () => {
+  test('docs sidebar links update the rendered page', async ({ page, goto }) => {
+    await goto('/')
+    await page.getByRole('link', { name: 'Docs', exact: true }).first().click()
+
+    const aside = page.locator('aside').first()
+    await aside.evaluate(element => element.setAttribute('data-navigation-test', 'persistent'))
+
+    const installationLink = page.locator('aside a').filter({ hasText: 'Installation' }).first()
+    const installationPath = await installationLink.getAttribute('href')
+    await installationLink.click()
+
+    await expect(page).toHaveURL(installationPath!)
+    await expect(page.getByRole('heading', { level: 1, name: 'Installation' })).toBeVisible()
+    await expect(aside).toHaveAttribute('data-navigation-test', 'persistent')
+  })
+
   test('key pages load successfully', async ({ page, goto }) => {
     const pages = ['/templates', '/blog', '/showcase', '/team']
 


### PR DESCRIPTION
Reported on Discord:

Steps to reproduce:

1. Open https://nuxt.com/
2. Click "Docs" on the top navbar
3. Click any sidebar option

Expected: User gets navigated.
Actual: No navigation happening, but url path changes. 

Happens on both Firefox & Chromium-based browsers.

This PR attempts to fix it