### PR TITLE
fix: silence autoprefixer gradient warning on login background

### DIFF
--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -149,7 +149,8 @@ const recentChats = [
         <div class="absolute -top-40 -right-40 size-[700px] bg-primary/12 rounded-full blur-3xl" />
         <div class="absolute top-1/3 -left-40 size-[500px] bg-primary/6 rounded-full blur-3xl" />
         <div class="absolute -bottom-40 right-1/4 size-[500px] bg-sky-500/5 rounded-full blur-3xl" />
-        <div class="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,rgba(255,255,255,0.06)_1px,transparent_0)] bg-size-[28px_28px] mask-[radial-gradient(ellipse_70%_60%_at_50%_50%,black,transparent_85%)]" />
+        <!-- mask center is 50.01% (not 50%) on purpose: at exactly 50% lightningcss drops the default `at …`, leaving `radial-gradient(70% 60%, …)` which autoprefixer misreads as legacy positional syntax and warns on. The sub-pixel offset keeps `at …` in the output and is visually identical. -->
+        <div class="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,rgba(255,255,255,0.06)_1px,transparent_0)] bg-size-[28px_28px] mask-[radial-gradient(ellipse_70%_60%_at_50%_50.01%,black,transparent_85%)]" />
       </div>
 
       <div class="relative h-full flex flex-col items-center justify-center px-8 xl:px-16 py-20 gap-8">


### PR DESCRIPTION
## Problem

Every build logs a warning (with a `^^^^` code frame) like:

```
Gradient has outdated direction syntax. New syntax is like `closest-side at 0 0` instead of `0 0, closest-side`.
| ...mask-image:radial-gradient(70% 60%,#000,#0000 85%)...
```

## Cause

It's a **false positive from autoprefixer** (Nuxt's default postcss plugin), not lightningcss:

1. The login background dot-grid mask is `mask-[radial-gradient(ellipse_70%_60%_at_50%_50%,black,transparent_85%)]`.
2. lightningcss minifies it and drops the default center → `radial-gradient(70% 60%, #000, #0000 85%)`.
3. autoprefixer then reads the leading `70% 60%` as a *legacy position* and warns — even though the CSS is valid modern syntax. The build isn't affected, just noisy.

## Fix

Nudge the mask center from `50%` to `50.01%`. lightningcss can no longer drop it as the default, so the minified output keeps `at 50% 50.01%`; with the explicit `at …` present, autoprefixer no longer misparses it. The 0.01% offset is sub-pixel — visually identical.

Verified by running the real `lightningcss → autoprefixer` pipeline over the gradient: warning present before, gone after. A comment on the element documents why the value isn't a round `50%`.