### PR TITLE
docs: add bloggrify template

### DIFF
--- a/content/templates/bloggrify.yml
+++ b/content/templates/bloggrify.yml
@@ -1,0 +1,6 @@
+name: 'Bloggrify'
+slug: 'bloggrify'
+description: 'Run a blog from Markdown files, with themes, SEO and analytics preconfigured.'
+repo: 'bloggrify/bloggrify'
+demo: 'https://minimalist.bloggrify.com'
+badge: 'Free'


### PR DESCRIPTION
Adds [Bloggrify](https://github.com/bloggrify/bloggrify) to the templates list.

Bloggrify is a Nuxt layer for blogging, built on Nuxt Content 3 and Nuxt UI 4. Themes extend `@bloggrify/core`, which handles posts, archives, tags, categories and authors, along with SEO (sitemap, robots, schema.org, OG images), RSS, search, and analytics and newsletter integrations.

MIT licensed. The demo points at the bundled `minimalist` theme.

Disclosure: I maintain Bloggrify.
