### PR TITLE
docs: update Rspack links to rspack.rs

### DIFF
--- a/content/blog/46.v4-5.md
+++ b/content/blog/46.v4-5.md
@@ -47,7 +47,7 @@ Vite 8 is a major version bump. If you depend on Vite directly (custom plugins, 
 
 ## 🦀 Rspack 2 and Rsbuild
 
-If you use the Rspack builder, this release is a substantial upgrade. We've moved to [Rspack 2](https://www.rspack.dev/blog/announcing-2-0) ([#34929](https://github.com/nuxt/nuxt/pull/34929)), which is faster and lighter, and rebuilt the builder on top of [`@rsbuild/core`](https://rsbuild.dev) ([#35489](https://github.com/nuxt/nuxt/pull/35489)).
+If you use the Rspack builder, this release is a substantial upgrade. We've moved to [Rspack 2](https://www.rspack.rs/blog/announcing-2-0) ([#34929](https://github.com/nuxt/nuxt/pull/34929)), which is faster and lighter, and rebuilt the builder on top of [`@rsbuild/core`](https://rsbuild.dev) ([#35489](https://github.com/nuxt/nuxt/pull/35489)).
 
 The public surface stays the same. You still opt in with `builder: 'rspack'` and the existing `rspack:*` hooks continue to work:
 

--- a/content/index.yml
+++ b/content/index.yml
@@ -349,8 +349,8 @@ foundation:
       color: '#F93920'
       gradient: 'bg-gradient-to-br from-[#F93920]/10 from-5% via-transparent via-50% to-transparent'
       link:
-        label: rspack.dev
-        to: https://rspack.dev
+        label: rspack.rs
+        to: https://rspack.rs
     - id: nitro
       title: Server with Nitro
       description: Nuxt uses Nitro as server engine to build versatile full-stack web applications, ready for deployment on any platform.


### PR DESCRIPTION
## Summary

Update the Rspack links to use [rspack.rs](https://rspack.rs/), which is the official Rspack domain now. See https://github.com/web-infra-dev/rspack.