### PR TITLE
fix(docs): correct Nuxt 4.5 release links

### DIFF
--- a/content/blog/46.v4-5.md
+++ b/content/blog/46.v4-5.md
@@ -35,7 +35,7 @@ Nuxt 3 reaches end-of-life on **July 31, 2026**, so this is one of the last few 
 
 Alongside v4.5.0 we're publishing a maintenance patch for the 3.x line (**v3.21.9**) with the compatible bug fixes and smaller improvements from this release backported. The headline items here (Vite 8, Rspack 2, `unhead` v3, `unctx` v3) are major upgrades and stay v4-only, so 3.x remains stable as it approaches end-of-life.
 
-## ⚡ Vite 8
+:h2[⚡️ Vite 8]{#vite-8}
 
 Nuxt now runs on [Vite 8](https://vite.dev) ([#34256](https://github.com/nuxt/nuxt/pull/34256)). This brings faster cold starts, the latest Rolldown-powered internals, and many upstream improvements from the Vite team.
 

--- a/content/blog/46.v4-5.md
+++ b/content/blog/46.v4-5.md
@@ -35,7 +35,7 @@ Nuxt 3 reaches end-of-life on **July 31, 2026**, so this is one of the last few 
 
 Alongside v4.5.0 we're publishing a maintenance patch for the 3.x line (**v3.21.9**) with the compatible bug fixes and smaller improvements from this release backported. The headline items here (Vite 8, Rspack 2, `unhead` v3, `unctx` v3) are major upgrades and stay v4-only, so 3.x remains stable as it approaches end-of-life.
 
-:h2[⚡️ Vite 8]{#vite-8}
+## ⚡️ Vite 8
 
 Nuxt now runs on [Vite 8](https://vite.dev) ([#34256](https://github.com/nuxt/nuxt/pull/34256)). This brings faster cold starts, the latest Rolldown-powered internals, and many upstream improvements from the Vite team.
 

--- a/content/blog/46.v4-5.md
+++ b/content/blog/46.v4-5.md
@@ -158,7 +158,7 @@ Navigating to `/parent/child` renders `child.vue` into the default outlet and `c
 `definePageMeta` is read from the default route file only, and per-view rendering modes aren't supported (the parent page's mode applies to the default view).
 ::
 
-:read-more{to="/docs/guide/directory-structure/app/pages#named-views"}
+:read-more{to="/docs/guide/directory-structure/app/pages#named-views-v45"}
 
 ## 🚦 `enabled` Option for `useFetch` and `useAsyncData`
 

--- a/content/blog/46.v4-5.md
+++ b/content/blog/46.v4-5.md
@@ -35,7 +35,7 @@ Nuxt 3 reaches end-of-life on **July 31, 2026**, so this is one of the last few 
 
 Alongside v4.5.0 we're publishing a maintenance patch for the 3.x line (**v3.21.9**) with the compatible bug fixes and smaller improvements from this release backported. The headline items here (Vite 8, Rspack 2, `unhead` v3, `unctx` v3) are major upgrades and stay v4-only, so 3.x remains stable as it approaches end-of-life.
 
-## ⚡️ Vite 8
+## ⚡ Vite 8
 
 Nuxt now runs on [Vite 8](https://vite.dev) ([#34256](https://github.com/nuxt/nuxt/pull/34256)). This brings faster cold starts, the latest Rolldown-powered internals, and many upstream improvements from the Vite team.
 


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### 📚 Description

Fixes the ugly Vite 8 and broken Named Views section links in the Nuxt 4.5 release notes.