### PR TITLE
fix(docs): correct spelling typos in blog and agency pages

### DIFF
--- a/content/blog/11.v3-4.md
+++ b/content/blog/11.v3-4.md
@@ -122,7 +122,7 @@ We've also taken the opportunity to do some cleanup in this minor release.
 1. Previously it was possible to pass the `x-nuxt-no-ssr` header (undocumented) to force SPA rendering. We've now disabled this behaviour by default but you can get it back by setting `experimental.respectNoSSRHeader` to true. Alternatively, you can set `event.context.nuxt.noSSR` on the server to force SPA rendering.
 2. We've [removed the (deprecated) `#head` alias](https://github.com/nuxt/nuxt/pull/20111) and also disabled the [polyfill for `@vueuse/head` behaviour](https://github.com/nuxt/nuxt/pull/20131) by default. (It can still be enabled with `experimental.polyfillVueUseHead`.)
 3. We've [removed the (deprecated) `experimental.viteNode` option](https://github.com/nuxt/nuxt/pull/20112). It can be configured instead with `vite.devBundler`.
-4. We've [deprecated accessing public runtime config without the `public` key](https://github.com/nuxt/nuxt/pull/20082). This was an undocument compatibility measure with Nuxt 2 and we plan to remove it entirely in v3.5.
+4. We've [deprecated accessing public runtime config without the `public` key](https://github.com/nuxt/nuxt/pull/20082). This was an undocumented compatibility measure with Nuxt 2 and we plan to remove it entirely in v3.5.
 5. To fix a bug with our vue-router integration, we now generate a slightly different path matching syntax. If you were relying on the exact path generated, have a look at https://github.com/nuxt/nuxt/pull/19902 for more information.
 
 ## ✅ Upgrading

--- a/content/blog/17.v3-8.md
+++ b/content/blog/17.v3-8.md
@@ -135,7 +135,7 @@ Once we have cross-runtime support, we will enable it by default.
 
 You can define your own [`<NuxtLink>`](/docs/api/components/nuxt-link) components with the [`defineNuxtLink`](/docs/api/components/nuxt-link#definenuxtlink-signature) utility.
 
-Today, you can cutomize the options for the built-in [`<NuxtLink>`](/docs/api/components/nuxt-link), directly in your `nuxt.config.ts` file ([#23724](https://github.com/nuxt/nuxt/pull/23724)).
+Today, you can customize the options for the built-in [`<NuxtLink>`](/docs/api/components/nuxt-link), directly in your `nuxt.config.ts` file ([#23724](https://github.com/nuxt/nuxt/pull/23724)).
 
 This can enable you to enforce trailing slash behaviour across your entire site, for example:
 ```ts [nuxt.config.ts]
@@ -210,7 +210,7 @@ Every commit to the `main` branch of Nuxt is automatically deployed to a new rel
 - ... and so on.
 
 ::read-more{to="/docs/guide/going-further/nightly-release-channel#nightly-release-channel"}
-Read more about the **Nighly Release Channel**.
+Read more about the **Nightly Release Channel**.
 ::
 
 ### ⚗️ Nitro v2.7

--- a/content/blog/18.nuxt-devtools-v1-0.md
+++ b/content/blog/18.nuxt-devtools-v1-0.md
@@ -63,7 +63,7 @@ From the overview, Nuxt DevTools is an in-app DevTools that lives alongside your
 We believe this is a better approach than the traditional browser extension DevTools, as it's:
 
 - **Works across all browsers**, and even on mobile devices! - The capability of browser extension DevTools are limited by the APIs each browsers provides, and also maintain multiple extensions would require a lot of effort. This approach would allow us to focus more on the functionality and features, while having it accessible to users on any browsers and devices.
-- **Build tools integrations** - Tranditionally browser extension DevTools are only able to access the runtime context of your app and have no access to the build tools. Having the DevTools comes with Nuxt, allows us to communicate with the build tools and provide much more insights and features.
+- **Build tools integrations** - Traditionally browser extension DevTools are only able to access the runtime context of your app and have no access to the build tools. Having the DevTools comes with Nuxt, allows us to communicate with the build tools and provide much more insights and features.
 - **Avoid layout shifts** - Having the DevTools as a floating panel would avoid the layout shifts when toggling the DevTools.
 
 ### Pages View
@@ -128,7 +128,7 @@ Plugins Overview list all the [plugins](/docs/guide/directory-structure/plugins)
 
 ### Timeline
 
-Timeline is a tool for you to check when and how each composable been called. Different from browser DevTools' performance tools, this tab only check the high-level composables combining with other events like route navigration, which is closer to day-to-day use. It also records the arguments and return values of each call, so you can better understand what's going on under the hood.
+Timeline is a tool for you to check when and how each composable been called. Different from browser DevTools' performance tools, this tab only check the high-level composables combining with other events like route navigation, which is closer to day-to-day use. It also records the arguments and return values of each call, so you can better understand what's going on under the hood.
 
 ::warning
 As of November 2023, the Timeline is still an experimental feature that requires manually opt-in.

--- a/content/blog/18.nuxt-devtools-v1-0.md
+++ b/content/blog/18.nuxt-devtools-v1-0.md
@@ -128,7 +128,7 @@ Plugins Overview list all the [plugins](/docs/guide/directory-structure/plugins)
 
 ### Timeline
 
-Timeline is a tool for you to check when and how each composable been called. Different from browser DevTools' performance tools, this tab only check the high-level composables combining with other events like route navigation, which is closer to day-to-day use. It also records the arguments and return values of each call, so you can better understand what's going on under the hood.
+Timeline is a tool for you to check when and how each composable has been called. Different from browser DevTools' performance tools, this tab only checks the high-level composables combining with other events like route navigation, which is closer to day-to-day use. It also records the arguments and return values of each call, so you can better understand what's going on under the hood.
 
 ::warning
 As of November 2023, the Timeline is still an experimental feature that requires manually opt-in.

--- a/content/blog/21.shiki-v1.md
+++ b/content/blog/21.shiki-v1.md
@@ -148,7 +148,7 @@ If you want to give Shiki a try in your own website, here you can find some inte
 
 - [Nuxt](https://shiki.style/packages/nuxt)
   - If using [Nuxt Content](https://content.nuxt.com/), Shiki is [build-in](https://content.nuxt.com/get-started/configuration#highlight). For Twoslash, you can add [`nuxt-content-twoslash`](https://github.com/antfu/nuxt-content-twoslash) on top.
-  - If not, you can use [`nuxt-shiki`](https://github.com/pi0/nuxt-shiki) to use Shiki as Vue component or composibles.
+  - If not, you can use [`nuxt-shiki`](https://github.com/pi0/nuxt-shiki) to use Shiki as Vue component or composables.
 - [VitePress](https://shiki.style/packages/vitepress) 
   - Shiki is [built-in](https://vitepress.dev/guide/markdown#syntax-highlighting-in-code-blocks). For Twoslash, you can use [`vitepress-twoslash`](https://shiki.style/packages/vitepress#twoslash).
 - Low-level integrations - Shiki provides official integrations for markdown compilers:

--- a/content/blog/3.introducing-nuxt-devtools.md
+++ b/content/blog/3.introducing-nuxt-devtools.md
@@ -34,7 +34,7 @@ Moreover, features such as the [layout system](/docs/guide/directory-structure/l
 
 Conventions like [file-based routing](/docs/guide/directory-structure/pages) and [file-based server APIs](https://nitro.unjs.io/guide/introduction/routing) making the routing intuitive and effortless.
 
-[Components auto-imports](/docs/guide/directory-structure/components) makes it easy to create shared components that are directly available in any Vue file. Unlike global components, they are code-split. We also introduced [composables auto-import](/docs/guide/concepts/auto-imports), where all APIs from Vue are directly available. Nuxt modules can also provide their custom composables to be auto-imported, as well as your [local composables](/docs/guide/directory-structure/composables).
+[Components auto-imports](/docs/guide/directory-structure/components) make it easy to create shared components that are directly available in any Vue file. Unlike global components, they are code-split. We also introduced [composables auto-import](/docs/guide/concepts/auto-imports), where all APIs from Vue are directly available. Nuxt modules can also provide their custom composables to be auto-imported, as well as your [local composables](/docs/guide/directory-structure/composables).
 
 Recently, we introduced client and server-only components, which can be used by adding `.client` and `.server` to the filename. All these conventions are fully typed and developers can even have type autocomplete when doing route navigation or fetching data from APIs. **These conventions significantly reduce boilerplate code, avoid duplications, and improve productivity.**
 
@@ -125,7 +125,7 @@ Plugins tab shows all the plugins you are using in your app. As plugins runs bef
 
 ### Hooks
 
-Hooks tab can help you to monitor the time spent in each hook from both client and server side. You can also see how many listeners registered to each hook, and how many times they have been invoked. This can be helpful to find performance bottlenecks.
+Hooks tab can help you to monitor the time spent in each hook from both client and server side. You can also see how many listeners are registered to each hook, and how many times they have been invoked. This can be helpful to find performance bottlenecks.
 
 ![nuxt-devtools-tab-hooks](/assets/blog/devtools/tab-hooks.png)
 

--- a/content/blog/3.introducing-nuxt-devtools.md
+++ b/content/blog/3.introducing-nuxt-devtools.md
@@ -22,7 +22,7 @@ In this post, we will explore the reasons behind the creation of Nuxt DevTools, 
 
 Over the recent years, there has been an increasing focus on Developer Experience (DX). Tools and frameworks have been striving to improve the DX. Along the way, Nuxt introduced many innovative features and conventions to make your day-to-day development easier and more efficient.
 
-In Nuxt 3, we switched to [Vite](https://vitejs.dev/) as the default bundler for the instant hot module replacement (HMR) during developement, creating a faster feedback loop to your workflow. Additionally, we have introduced [Nitro](https://github.com/unjs/nitro), a new server engine that allows you to deploy your Nuxt app to any hosting service, such as [Vercel](https://vercel.com), [Netlify](https://netlify.com), [Cloudflare](https://cloudflare.com) and [more](https://nitro.unjs.io/deploy) **with zero-config**.
+In Nuxt 3, we switched to [Vite](https://vitejs.dev/) as the default bundler for the instant hot module replacement (HMR) during development, creating a faster feedback loop to your workflow. Additionally, we have introduced [Nitro](https://github.com/unjs/nitro), a new server engine that allows you to deploy your Nuxt app to any hosting service, such as [Vercel](https://vercel.com), [Netlify](https://netlify.com), [Cloudflare](https://cloudflare.com) and [more](https://nitro.unjs.io/deploy) **with zero-config**.
 
 Nuxt offers many common practices built-in:
 - Write TypeScript and ESM out-of-the-box throughout your codebase.
@@ -34,7 +34,7 @@ Moreover, features such as the [layout system](/docs/guide/directory-structure/l
 
 Conventions like [file-based routing](/docs/guide/directory-structure/pages) and [file-based server APIs](https://nitro.unjs.io/guide/introduction/routing) making the routing intuitive and effortless.
 
-[Components auto-imports](/docs/guide/directory-structure/components) makes it easy to create shared components that are directly available in any Vue file. Unlike global components, they are code-splitted. We also introduced [composables auto-import](/docs/guide/concepts/auto-imports), where all APIs from Vue are directly available. Nuxt modules can also provide their custom composables to be auto-imported, as well as your [local composables](/docs/guide/directory-structure/composables).
+[Components auto-imports](/docs/guide/directory-structure/components) makes it easy to create shared components that are directly available in any Vue file. Unlike global components, they are code-split. We also introduced [composables auto-import](/docs/guide/concepts/auto-imports), where all APIs from Vue are directly available. Nuxt modules can also provide their custom composables to be auto-imported, as well as your [local composables](/docs/guide/directory-structure/composables).
 
 Recently, we introduced client and server-only components, which can be used by adding `.client` and `.server` to the filename. All these conventions are fully typed and developers can even have type autocomplete when doing route navigation or fetching data from APIs. **These conventions significantly reduce boilerplate code, avoid duplications, and improve productivity.**
 
@@ -125,7 +125,7 @@ Plugins tab shows all the plugins you are using in your app. As plugins runs bef
 
 ### Hooks
 
-Hooks tab can help you to monitor the time spent in each hook from both client and server side. You can also see how many lisenters registed to each hook, and how many times they have been invoked. This can be helpful to find performance bottlenecks.
+Hooks tab can help you to monitor the time spent in each hook from both client and server side. You can also see how many listeners registered to each hook, and how many times they have been invoked. This can be helpful to find performance bottlenecks.
 
 ![nuxt-devtools-tab-hooks](/assets/blog/devtools/tab-hooks.png)
 
@@ -181,7 +181,7 @@ With the ecosystem in mind, Nuxt DevTools to designed to be flexible and extenda
 
 ![nuxt-devtools-tab-nuxt-icon](/assets/blog/devtools/tab-icones.png)
 
-[Nuxt Vitest module](https://nuxt.com/modules/vitest) provides Vitest UI for tests runing with the same pipeline as your Nuxt app.
+[Nuxt Vitest module](https://nuxt.com/modules/vitest) provides Vitest UI for tests running with the same pipeline as your Nuxt app.
 
 ![nuxt-devtools-tab-vitest](/assets/blog/devtools/tab-vitest.png)
 

--- a/content/blog/6.introducing-smart-prefetching.md
+++ b/content/blog/6.introducing-smart-prefetching.md
@@ -14,7 +14,7 @@ category: Release
 
 ## Introducing Smart prefetching ⚡️
 
-Starting from [Nuxt v2.4.0](https://github.com/nuxt/nuxt.js/releases/tag/v2.4.0), Nuxt will automagically prefetch the code-split pages linked with `<nuxt-link>` when visible in the viewport **by default**. This hugely improves the end user performances, inspired by [quicklink](https://github.com/GoogleChromeLabs/quicklink).
+Starting from [Nuxt v2.4.0](https://github.com/nuxt/nuxt.js/releases/tag/v2.4.0), Nuxt will automagically prefetch the code-split pages linked with `<nuxt-link>` when visible in the viewport **by default**. This hugely improves the end-user performance, inspired by [quicklink](https://github.com/GoogleChromeLabs/quicklink).
 
 ![nuxt-prefetch-comparison](/assets/blog/nuxt-prefetch-comparison.gif){alt="nuxt-prefetch-comparison" class="rounded-lg border border-gray-700"}
 

--- a/content/blog/6.introducing-smart-prefetching.md
+++ b/content/blog/6.introducing-smart-prefetching.md
@@ -1,6 +1,6 @@
 ---
 title: Introducing Smart Prefetching
-description: 'Starting from Nuxt v2.4.0, Nuxt will automagically prefetch the code-splitted pages linked with a nuxt-link when visible in the viewport by default.'
+description: 'Starting from Nuxt v2.4.0, Nuxt will automagically prefetch the code-split pages linked with a nuxt-link when visible in the viewport by default.'
 image: /assets/blog/introducing-smart-prefetching.png
 date: 2019-01-28
 authors:
@@ -14,7 +14,7 @@ category: Release
 
 ## Introducing Smart prefetching ⚡️
 
-Starting from [Nuxt v2.4.0](https://github.com/nuxt/nuxt.js/releases/tag/v2.4.0), Nuxt will automagically prefetch the code-splitted pages linked with `<nuxt-link>` when visible in the viewport **by default**. This hugely improves the end user performances, inspired by [quicklink](https://github.com/GoogleChromeLabs/quicklink).
+Starting from [Nuxt v2.4.0](https://github.com/nuxt/nuxt.js/releases/tag/v2.4.0), Nuxt will automagically prefetch the code-split pages linked with `<nuxt-link>` when visible in the viewport **by default**. This hugely improves the end user performances, inspired by [quicklink](https://github.com/GoogleChromeLabs/quicklink).
 
 ![nuxt-prefetch-comparison](/assets/blog/nuxt-prefetch-comparison.gif){alt="nuxt-prefetch-comparison" class="rounded-lg border border-gray-700"}
 

--- a/content/enterprise/agencies/05.maas.md
+++ b/content/enterprise/agencies/05.maas.md
@@ -36,7 +36,7 @@ regions:
 location: Germany
 ---
 
-### **Nuxt Development by Magic as a Servic**
+### **Nuxt Development by Magic as a Service**
 
 With deep expertise in Nuxt and Vue, we build seamless, scalable applications that combine technical precision, elegant design, and intuitive user experiences. From lean MVPs to large-scale digital platforms, we develop ambitious products that solve real problems—with a focus on seamless performance, elegant design, and user-first experiences.
 

--- a/content/enterprise/agencies/06.wimadev.md
+++ b/content/enterprise/agencies/06.wimadev.md
@@ -21,4 +21,4 @@ regions:
 location: Berlin
 ---
 
-We help you plan, develop, extend and maintain your enterprise grade Nuxt application and Node.js backend. Our customers include big international tech corporations and some of Germanys most well known brands. We have been developing almost exclusively with Nuxt since Nuxt 2 was released about 5 years ago.
+We help you plan, develop, extend and maintain your enterprise grade Nuxt application and Node.js backend. Our customers include big international tech corporations and some of Germany's most well known brands. We have been developing almost exclusively with Nuxt since Nuxt 2 was released about 5 years ago.

--- a/content/enterprise/agencies/06.wimadev.md
+++ b/content/enterprise/agencies/06.wimadev.md
@@ -21,4 +21,4 @@ regions:
 location: Berlin
 ---
 
-We help you plan, develop, extend and maintain your enterprise grade Nuxt application and Node.js backend. Our customers include big international tech corporations and some of Germany's most well known brands. We have been developing almost exclusively with Nuxt since Nuxt 2 was released about 5 years ago.
+We help you plan, develop, extend and maintain your enterprise-grade Nuxt application and Node.js backend. Our customers include big international tech corporations and some of Germany's most well-known brands. We have been developing almost exclusively with Nuxt since Nuxt 2 was released about 5 years ago.

--- a/content/enterprise/agencies/13.webreinvent.md
+++ b/content/enterprise/agencies/13.webreinvent.md
@@ -27,7 +27,7 @@ color:
 regions:
   - Asia
   - North America
-location: New Dehli, IND - Louisville, KY
+location: New Delhi, IND - Louisville, KY
 ---
 
 WebReinvent has 12+ years of experience building software and a team of 50+ software professionals including software developers, UI/UX designers, testers, DevOps, project managers, etc. The team is well-versed in the Nuxt ecosystem and has delivered multiple high-performance web apps, dashboards, real-time apps, multi-tenant SaaS applications, etc.


### PR DESCRIPTION
This PR fixes 15 spelling mistakes found via `cspell` across blog posts and enterprise agency pages. No code or API behavior is changed; only prose corrections.

## Changes

| File | Before | After |
| --- | --- | --- |
| content/blog/3.introducing-nuxt-devtools.md | developement | development |
| content/blog/3.introducing-nuxt-devtools.md | code-splitted | code-split |
| content/blog/3.introducing-nuxt-devtools.md | lisenters | listeners |
| content/blog/3.introducing-nuxt-devtools.md | registed | registered |
| content/blog/3.introducing-nuxt-devtools.md | runing | running |
| content/blog/6.introducing-smart-prefetching.md | code-splitted | code-split |
| content/blog/11.v3-4.md | undocument | undocumented |
| content/blog/17.v3-8.md | cutomize | customize |
| content/blog/17.v3-8.md | Nighly Release Channel | Nightly Release Channel |
| content/blog/18.nuxt-devtools-v1-0.md | Tranditionally | Traditionally |
| content/blog/18.nuxt-devtools-v1-0.md | route navigration | route navigation |
| content/blog/21.shiki-v1.md | composibles | composables |
| content/enterprise/agencies/05.maas.md | Magic as a Servic | Magic as a Service |
| content/enterprise/agencies/06.wimadev.md | Germanys | Germany's |
| content/enterprise/agencies/13.webreinvent.md | New Dehli | New Delhi |

## Checklist
- [x] Only prose/typos changed
- [x] No breaking changes
- [x] Verified locally