### PR TITLE
fix(content): pin libsql database adapter for vercel runtime

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -86,6 +86,13 @@ export default defineNuxtConfig({
     preference: 'dark'
   },
   content: {
+    // @nuxt/content's nuxthub preset only maps `hub.db` into `content.database` when `hub.db` is a string.
+    // With the object form it falls back to better-sqlite3, whose native addon fails to load on Vercel.
+    // See https://github.com/nuxt/content/issues/3821
+    database: {
+      type: 'libsql',
+      url: 'file:/tmp/sqlite.db'
+    },
     build: {
       markdown: {
         highlight: {


### PR DESCRIPTION
Fixes the `POST /__nuxt_content/<collection>/query` 500s in production, which broke every content-backed MCP tool on `/mcp`.

### Root cause

#2354 switched `hub.db` from `'sqlite'` to the object form to set `applyMigrationsDuringBuild: false`. `@nuxt/content`'s nuxthub preset only maps `hub.db` into `content.database` when it's a string, so `content.database` silently fell back to `{ type: 'sqlite' }` and the runtime adapter went from `db0/connectors/libsql/node` to `db0/connectors/better-sqlite3`. The better-sqlite3 native addon fails to load in the Vercel lambda:

```
Error: Module did not self-register: '/var/task/node_modules/better-sqlite3/build/Release/better_sqlite3.node'
  code: 'ERR_DLOPEN_FAILED'
```

Every runtime collection query 500s since. Rendered pages kept working because they're prerendered and client-side navigation uses the WASM database, so the site looked healthy and the #2354 preview checks passed while the query endpoint was down. The `@nuxt/content` 3.15.2 bump in #2348 is unrelated, better-sqlite3 didn't change there.

Upstream issue: nuxt/content#3821

### Fix

Pin `content.database` to the libsql adapter with `file:/tmp/sqlite.db`, exactly what the preset resolved before #2354, and keep `applyMigrationsDuringBuild: false`. On first runtime query the content dump gets imported into `/tmp/sqlite.db`, the standard content v3 flow.

### Verification

Reproduced the failure on production with a curl against `/mcp` (`get-documentation-page` returns the 500). Will verify the fix on this PR's preview deployment: MCP content tools, `/api/navigation.json`, homepage and docs pages. Results in a comment below.
