### PR TITLE
fix: update Evan You testimonial link to active X profile

### DIFF
--- a/content/index.yml
+++ b/content/index.yml
@@ -374,7 +374,7 @@ testimonial:
   author:
     name: 'Evan You'
     description: 'Creator of Vue.js and Vite'
-    to: 'https://x.com/youyuxi'
+    to: 'https://x.com/evanyou'
     avatar:
       src: 'https://ipx.nuxt.com/f_auto,s_40x40/gh_avatar/yyx990803'
       srcset: 'https://ipx.nuxt.com/f_auto,s_80x80/gh_avatar/yyx990803 2x'


### PR DESCRIPTION
## Summary

Fixes #2359

The homepage Evan You testimonial linked to `https://x.com/youyuxi`, which returns "This account doesn't exist." Updated it to `https://x.com/evanyou`, Evan You's active X account.

## Test plan

- [ ] Open https://nuxt.com/ (or run locally)
- [ ] Scroll to the Evan You testimonial
- [ ] Click **Evan You** and confirm it opens https://x.com/evanyou


Made with [Cursor](https://cursor.com)