### PR TITLE
fix: link npm download stats to npmjs.com

### DIFF
--- a/app/components/module/ModuleItem.vue
+++ b/app/components/module/ModuleItem.vue
@@ -148,7 +148,7 @@ const items = computed(() => [
             <UTooltip text="Monthly NPM Downloads">
               <NuxtLink
                 class="flex items-center gap-1 hover:text-highlighted"
-                :to="`https://npmx.dev/package-stats/${module.npm}/v/${module.stats.version}`"
+                :to="`https://npmx.dev/package-stats/${module.npm}/v/${module.stats.version}?granularity=monthly`"
                 target="_blank"
               >
                 <UIcon name="i-lucide-circle-arrow-down" class="size-4 shrink-0" />

--- a/app/components/module/ModuleItem.vue
+++ b/app/components/module/ModuleItem.vue
@@ -148,7 +148,7 @@ const items = computed(() => [
             <UTooltip text="Monthly NPM Downloads">
               <NuxtLink
                 class="flex items-center gap-1 hover:text-highlighted"
-                :to="`https://npmx.dev/package-stats/${module.npm}/v/{module.stats.version}`"
+                :to="`https://npmx.dev/package-stats/${module.npm}/v/${module.stats.version}`"
                 target="_blank"
               >
                 <UIcon name="i-lucide-circle-arrow-down" class="size-4 shrink-0" />

--- a/app/components/module/ModuleItem.vue
+++ b/app/components/module/ModuleItem.vue
@@ -89,7 +89,7 @@ const items = computed(() => [
     {
       label: 'View on npm',
       icon: 'i-lucide-package',
-      to: `https://www.npmjs.com/package/${props.module.npm}`,
+      to: `https://npmx.dev/package/${props.module.npm}`,
       target: '_blank'
     }
   ]
@@ -148,7 +148,7 @@ const items = computed(() => [
             <UTooltip text="Monthly NPM Downloads">
               <NuxtLink
                 class="flex items-center gap-1 hover:text-highlighted"
-                :to="`https://www.npmjs.com/package/${module.npm}`"
+                :to="`https://npmx.dev/package-stats/${module.npm}/v/{module.stats.version}`"
                 target="_blank"
               >
                 <UIcon name="i-lucide-circle-arrow-down" class="size-4 shrink-0" />

--- a/app/components/module/ModuleItem.vue
+++ b/app/components/module/ModuleItem.vue
@@ -89,7 +89,7 @@ const items = computed(() => [
     {
       label: 'View on npm',
       icon: 'i-lucide-package',
-      to: `https://npm.chart.dev/${props.module.npm}`,
+      to: `https://www.npmjs.com/package/${props.module.npm}`,
       target: '_blank'
     }
   ]
@@ -148,7 +148,7 @@ const items = computed(() => [
             <UTooltip text="Monthly NPM Downloads">
               <NuxtLink
                 class="flex items-center gap-1 hover:text-highlighted"
-                :to="`https://npm.chart.dev/${module.npm}`"
+                :to="`https://www.npmjs.com/package/${module.npm}`"
                 target="_blank"
               >
                 <UIcon name="i-lucide-circle-arrow-down" class="size-4 shrink-0" />

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -373,7 +373,7 @@ onMounted(() => {
     >
       <div class="flex flex-col md:flex-row gap-4">
         <div class="md:w-1/4 flex flex-col gap-4">
-          <UPageCard class="flex-1" variant="subtle" to="https://www.npmjs.com/package/nuxt">
+          <UPageCard class="flex-1" variant="subtle" :to="`https://npmx.dev/package-stats/nuxt/v/${stats.version}`">
             <div class="flex items-center gap-3">
               <div class="rounded-lg bg-default p-2 flex items-center justify-center border border-default">
                 <UIcon name="i-simple-icons-npm" class="text-red-500 size-6" />

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -373,7 +373,7 @@ onMounted(() => {
     >
       <div class="flex flex-col md:flex-row gap-4">
         <div class="md:w-1/4 flex flex-col gap-4">
-          <UPageCard class="flex-1" variant="subtle" :to="`https://npmx.dev/package-stats/nuxt/v/${stats.version}`">
+          <UPageCard class="flex-1" variant="subtle" :to="`https://npmx.dev/package-stats/nuxt/v/${stats.version}?granularity=monthly`">
             <div class="flex items-center gap-3">
               <div class="rounded-lg bg-default p-2 flex items-center justify-center border border-default">
                 <UIcon name="i-simple-icons-npm" class="text-red-500 size-6" />

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -373,7 +373,7 @@ onMounted(() => {
     >
       <div class="flex flex-col md:flex-row gap-4">
         <div class="md:w-1/4 flex flex-col gap-4">
-          <UPageCard class="flex-1" variant="subtle" to="https://npm.chart.dev/nuxt">
+          <UPageCard class="flex-1" variant="subtle" to="https://www.npmjs.com/package/nuxt">
             <div class="flex items-center gap-3">
               <div class="rounded-lg bg-default p-2 flex items-center justify-center border border-default">
                 <UIcon name="i-simple-icons-npm" class="text-red-500 size-6" />

--- a/app/pages/modules/[slug].vue
+++ b/app/pages/modules/[slug].vue
@@ -144,7 +144,7 @@ if (import.meta.server) {
 
       <div class="flex flex-col lg:flex-row lg:items-center gap-3 mt-4">
         <UTooltip text="Monthly NPM Downloads">
-          <NuxtLink class="flex items-center gap-1.5" :to="`https://www.npmjs.com/package/${module.npm}`" target="_blank">
+          <NuxtLink class="flex items-center gap-1.5" :to="`https://npmx.dev/package-stats/${module.npm}/v/{module.stats.version}`" target="_blank">
             <UIcon name="i-lucide-circle-arrow-down" class="size-5 shrink-0" />
             <span class="text-sm font-medium">{{ formatNumber(module.stats.downloads) }} downloads</span>
           </NuxtLink>

--- a/app/pages/modules/[slug].vue
+++ b/app/pages/modules/[slug].vue
@@ -144,7 +144,7 @@ if (import.meta.server) {
 
       <div class="flex flex-col lg:flex-row lg:items-center gap-3 mt-4">
         <UTooltip text="Monthly NPM Downloads">
-          <NuxtLink class="flex items-center gap-1.5" :to="`https://npmx.dev/package-stats/${module.npm}/v/{module.stats.version}`" target="_blank">
+          <NuxtLink class="flex items-center gap-1.5" :to="`https://npmx.dev/package-stats/${module.npm}/v/${module.stats.version}`" target="_blank">
             <UIcon name="i-lucide-circle-arrow-down" class="size-5 shrink-0" />
             <span class="text-sm font-medium">{{ formatNumber(module.stats.downloads) }} downloads</span>
           </NuxtLink>

--- a/app/pages/modules/[slug].vue
+++ b/app/pages/modules/[slug].vue
@@ -144,7 +144,7 @@ if (import.meta.server) {
 
       <div class="flex flex-col lg:flex-row lg:items-center gap-3 mt-4">
         <UTooltip text="Monthly NPM Downloads">
-          <NuxtLink class="flex items-center gap-1.5" :to="`https://npm.chart.dev/${module.npm}`" target="_blank">
+          <NuxtLink class="flex items-center gap-1.5" :to="`https://www.npmjs.com/package/${module.npm}`" target="_blank">
             <UIcon name="i-lucide-circle-arrow-down" class="size-5 shrink-0" />
             <span class="text-sm font-medium">{{ formatNumber(module.stats.downloads) }} downloads</span>
           </NuxtLink>

--- a/app/pages/modules/[slug].vue
+++ b/app/pages/modules/[slug].vue
@@ -144,7 +144,7 @@ if (import.meta.server) {
 
       <div class="flex flex-col lg:flex-row lg:items-center gap-3 mt-4">
         <UTooltip text="Monthly NPM Downloads">
-          <NuxtLink class="flex items-center gap-1.5" :to="`https://npmx.dev/package-stats/${module.npm}/v/${module.stats.version}`" target="_blank">
+          <NuxtLink class="flex items-center gap-1.5" :to="`https://npmx.dev/package-stats/${module.npm}/v/${module.stats.version}?granularity=monthly`" target="_blank">
             <UIcon name="i-lucide-circle-arrow-down" class="size-5 shrink-0" />
             <span class="text-sm font-medium">{{ formatNumber(module.stats.downloads) }} downloads</span>
           </NuxtLink>


### PR DESCRIPTION
## Summary

Fixes #2361

The homepage **Monthly downloads** card linked to `https://npm.chart.dev/nuxt`, which is unresponsive. Updated npm download links across the site to use the official npm package pages (`https://www.npmjs.com/package/...`), matching the pattern already used in `server/routes/raw/modules.md.get.ts`.

## Changes

- Homepage stats card → `https://www.npmjs.com/package/nuxt`
- Module detail page download link
- Module list item download link and context menu

## Test plan

- [ ] Open https://nuxt.com/ and click **Monthly downloads** → lands on https://www.npmjs.com/package/nuxt
- [ ] Open any module page and click the downloads link → lands on the correct npm package page
- [ ] Right-click a module in the modules list → **View on npm** opens the correct npm page


Made with [Cursor](https://cursor.com)