### PR TITLE
docs: clarify Firebase Cloud Functions coexistence

### DIFF
--- a/content/deploy/firebase.md
+++ b/content/deploy/firebase.md
@@ -164,7 +164,44 @@ You can read more about this in **Firebase Docs**.
 
 ## Other Cloud Functions
 
-You may be warned that other cloud functions will be deleted when you deploy your Nuxt project. This is because Nitro will deploy your entire project to firebase functions. If you want to deploy only your Nuxt project, you can use the `--only` flag:
+Firebase may warn that other Cloud Functions will be deleted when you deploy. That happens when `firebase.json` lists a single functions source and the CLI treats the deploy as replacing every function in the project.
+
+Nuxt can share a Firebase project with other functions. Configure multiple function sources with distinct `codebase` values:
+
+```json [firebase.json]
+{
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default"
+    },
+    {
+      "source": ".output/server",
+      "codebase": "nuxt"
+    }
+  ],
+  "hosting": [
+    {
+      "site": "<your_project_id>",
+      "public": ".output/public",
+      "cleanUrls": true,
+      "rewrites": [{ "source": "**", "function": "server" }]
+    }
+  ]
+}
+```
+
+::read-more{to="https://firebase.google.com/docs/functions/organize-functions?gen=2nd#managing_multiple_source_packages_monorepo" target="_blank"}
+See **Managing multiple source packages** in the Firebase docs.
+::
+
+To deploy only the Nuxt codebase and hosting:
+
+```bash
+firebase deploy --only functions:nuxt,hosting
+```
+
+With a single functions source (no separate `codebase`), target the `server` function instead:
 
 ```bash
 firebase deploy --only functions:server,hosting

--- a/content/deploy/firebase.md
+++ b/content/deploy/firebase.md
@@ -164,9 +164,11 @@ You can read more about this in **Firebase Docs**.
 
 ## Other Cloud Functions
 
-Firebase may warn that other Cloud Functions will be deleted when you deploy. That happens when `firebase.json` lists a single functions source and the CLI treats the deploy as replacing every function in the project.
+Firebase may warn that other Cloud Functions will be deleted when you deploy. That warning depends on `codebase` identifiers, not on how many function sources you list. Without a unique `codebase`, the CLI treats functions outside the current deploy as candidates for deletion.
 
-Nuxt can share a Firebase project with other functions. Configure multiple function sources with distinct `codebase` values:
+A single functions source can coexist with other functions if you give it a unique `codebase` (for example in a separate repository that deploys to the same Firebase project). Use a different `codebase` in each repository's `firebase.json`.
+
+In one repository, configure multiple function sources with distinct `codebase` values:
 
 ```json [firebase.json]
 {


### PR DESCRIPTION
### 🔗 Linked issue

fixes #1497

### 📚 Description

The Firebase deploy page only showed `firebase deploy --only`, so it sounded like other Cloud Functions could not live next to Nuxt. Firebase already supports multiple function sources with `codebase`.

I updated the Other Cloud Functions section with a multi-source `firebase.json` example, a link to Firebase's monorepo docs, and `--only` examples for both the `nuxt` codebase and a single-source setup.