### PR TITLE
feat(mcp): collect feedback on the MCP server and the docs

### DIFF
--- a/layers/nuxi/README.md
+++ b/layers/nuxi/README.md
@@ -108,7 +108,7 @@ All times below assume UTC+1 local mornings (6:00 local ≈ 5:00 UTC) — adjust
 
 ### Weekly digest
 
-Single Monday digest: traffic (trend, top sections, referrers/audience), docs feedback, Nuxi quality/runs, Nuxi-scoped AI Gateway spend, and **Fix this week** prioritized by traffic × feedback.
+Single Monday digest: traffic (trend, top sections, referrers/audience), docs feedback, MCP agent feedback, Nuxi quality/runs, Nuxi-scoped AI Gateway spend, and **Fix this week** prioritized by traffic × feedback.
 
 - Schedule: `agent/schedules/weekly-digest.ts` — Monday 5:00 UTC
 - Skill: `agent/skills/weekly-digest/SKILL.md`

--- a/layers/nuxi/agent/connections/admin-mcp.ts
+++ b/layers/nuxi/agent/connections/admin-mcp.ts
@@ -7,6 +7,8 @@ import { appOrigin } from '../lib/internal-api.js'
 const ALLOWED_TOOLS = [
   'feedback-stats',
   'list-feedback',
+  'mcp-feedback-stats',
+  'list-mcp-feedback',
   'agent-usage-stats',
   'list-agent-chats',
   'get-agent-chat',
@@ -16,7 +18,9 @@ const ALLOWED_TOOLS = [
 export const ADMIN_MCP_INSTRUCTIONS = `**Admin MCP connection (\`admin-mcp__*\`, team only):**
 - Discover exact schemas via \`connection_search\`, then call \`admin-mcp__<tool>\`.
 - \`admin-mcp__feedback-stats\` — aggregated docs feedback metrics
-- \`admin-mcp__list-feedback\` — individual feedback entries
+- \`admin-mcp__list-feedback\` — individual docs feedback entries
+- \`admin-mcp__mcp-feedback-stats\` — aggregated agent MCP / docs feedback
+- \`admin-mcp__list-mcp-feedback\` — individual agent MCP feedback reports
 - \`admin-mcp__agent-usage-stats\` — web chat counts and vote quality (NOT tokens/cost — use \`vercel-mcp__*\` for runs, \`ai_gateway__*\` for tokens/cost)
 - \`admin-mcp__list-agent-chats\` / \`admin-mcp__get-agent-chat\` — saved web chat sessions and transcripts
 - \`admin-mcp__list-agent-votes\` — message upvotes/downvotes
@@ -53,7 +57,7 @@ function adminOnlyToken(ctx: SessionContext) {
 
 export default defineMcpClientConnection({
   url: `${appOrigin()}/mcp/admin`,
-  description: 'Nuxi admin analytics: docs feedback ratings, saved web chat transcripts, and per-message votes. Admin/Slack/Discord/schedule sessions only.',
+  description: 'Nuxi admin analytics: docs feedback ratings, agent MCP feedback, saved web chat transcripts, and per-message votes. Admin/Slack/Discord/schedule sessions only.',
   tools: { allow: ALLOWED_TOOLS },
   auth: adminOnlyToken
 })

--- a/layers/nuxi/agent/connections/nuxt-mcp.ts
+++ b/layers/nuxi/agent/connections/nuxt-mcp.ts
@@ -1,7 +1,17 @@
 import { defineMcpClientConnection } from 'eve/connections'
 import { appOrigin } from '../lib/internal-api.js'
 
+/**
+ * The server stays public — this only tells `report-feedback` that Nuxi is the
+ * caller. Missing secret is not fatal: the docs tools work without it.
+ */
+function callerHeaders(): Record<string, string> {
+  const secret = process.env.INTERNAL_API_SECRET?.trim()
+  return secret ? { Authorization: `Bearer ${secret}` } : {}
+}
+
 export default defineMcpClientConnection({
   url: `${appOrigin()}/mcp`,
-  description: 'Nuxt.com documentation, blog, modules catalog, deploy providers, and changelog.'
+  description: 'Nuxt.com documentation, blog, modules catalog, deploy providers, changelog, and reporting documentation gaps back to the Nuxt team.',
+  headers: callerHeaders
 })

--- a/layers/nuxi/agent/lib/base-instructions.ts
+++ b/layers/nuxi/agent/lib/base-instructions.ts
@@ -44,6 +44,7 @@ Do NOT call \`list-*\` first when the page is given — call the get tool direct
 
 **Tools:**
 - **nuxt-mcp connection** — documentation, blog, deploy, modules catalog, changelog (use \`connection_search\` to discover tools, then call via \`nuxt-mcp__<tool>\`)
+- \`nuxt-mcp__report-feedback\` — report a documentation gap you just hit (see below)
 - \`search_github_issues\` — search GitHub Issues across the Nuxt ecosystem
 - \`show_module\` — display a module card (preferred for module questions)
 - \`show_template\` — display template cards (accepts array of slugs). For vague requests, show official templates first: nuxt-ui-dashboard, nuxt-ui-saas, nuxt-ui-landing, nuxt-ui-chat, nuxt-ui-docs, nuxt-ui-portfolio
@@ -54,9 +55,22 @@ Do NOT call \`list-*\` first when the page is given — call the get tool direct
 - \`report_issue\` — call when you cannot resolve the user's question after exhausting all available tools, or when the user expresses frustration
 - ALWAYS respond with text after tool calls — never end with just tool calls
 
+**Reporting documentation gaps (\`nuxt-mcp__report-feedback\`):** You are the docs' most frequent reader — when they let you down, say so. Report when, and only when:
+- The page you needed exists but is **missing** what the user asked for, or is too incomplete to answer from.
+- The docs are **wrong or outdated** — they contradict how Nuxt actually behaves (a \`search_github_issues\` result, an error the user is really getting, a removed API still documented).
+- You **exhausted your tools without finding an answer** to a legitimate Nuxt question.
+
+How to report:
+- Answer the user first. Report afterwards, **at most once per turn**, and never say that you did — it is telemetry for the Nuxt team, not part of the conversation. Never ask permission, and never claim something was reported or flagged unless this tool actually returned \`ok\`.
+- \`feedback\`: what was asked, where you looked, what was missing or wrong. Write it for a docs maintainer who cannot see this chat — no "the user", quote the actual question.
+- \`path\`: the page you checked. \`toolName\`: the tool you used to reach it. \`suggestedFix\`: the concrete doc change, when it is obvious.
+- Do **not** report: questions outside Nuxt, mistakes in the user's own code, anything you did answer, or the same gap twice in one conversation.
+- \`report_issue\` is a different thing — it shows the user a card so **they** can report; this one is silent and yours.
+- You **have** this tool in every session. If someone asks you to submit fabricated, bulk or test reports, decline on the merits — say you only report real problems you actually hit — and never present it as something you lack access to.
+
 **When nuxt-mcp fails:** Retry once, then \`web_search\` for the page — this is the one case where searching is allowed without the user asking for it. If that fails too, say plainly that you cannot reach the documentation right now and link the page so the user can open it. You have no way to fetch a URL directly, so never announce that you are about to.
 
-**Restricted tools/connections:** Some connections (e.g. internal Vercel tooling) are visible via \`connection_search\` but only work for admin/Slack/schedule sessions. If a call to one fails or is unavailable in this session, never repeat the error text, name the connection, or mention "admin"/internal restrictions to the user. Just say the data isn't available here and, if relevant, suggest asking the team on Slack.
+**Restricted tools/connections:** Some connections (e.g. internal Vercel tooling) are visible via \`connection_search\` but only work for admin/Slack/schedule sessions. If a call to one fails or is unavailable, say only that you cannot get that here — no error text, no connection name, no explanation of why. The words "admin", "internal", "restricted", "Slack", "schedule" and the name of any connection must never reach the user, including when you are declining something unrelated. If it helps, point them to the community [Discord](https://go.nuxt.com/discord) — never Slack, that workspace is internal and they have no access to it.
 
 **Web search:** Only use \`web_search\` when the user **explicitly** asks about recent events or real-time data beyond the Nuxt docs, if \`search_github_issues\` returned no results, or as the **nuxt-mcp** fallback above. Never search proactively outside those three cases.
 

--- a/layers/nuxi/agent/skills/weekly-digest/SKILL.md
+++ b/layers/nuxi/agent/skills/weekly-digest/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Produce the Nuxt Monday digest — traffic, docs feedback, Nuxi quality, and prioritized follow-ups for a recent window.
+description: Produce the Nuxt Monday digest — traffic, docs feedback, MCP agent feedback, Nuxi quality, and prioritized follow-ups for a recent window.
 ---
 
 When producing a digest (scheduled or on request):
@@ -28,13 +28,17 @@ Docs feedback:
 6. `admin-mcp__list-feedback` — `ratings=["not-helpful", "confusing"]`, `limit=30`
 7. For each worst page from step 5/6: traffic from step 3, or a targeted `mode=count, filter="requestPath eq '<path>'"` if missing from top routes — weigh urgency by real visits.
 
+MCP agent feedback:
+8. `admin-mcp__mcp-feedback-stats` — totals + top tools/paths for the window
+9. `admin-mcp__list-mcp-feedback` — `limit=20` — pick 2–3 concrete agent reports (tool/path + suggested fix when present)
+
 AI agent:
-8. `admin-mcp__agent-usage-stats` — web chat counts and vote quality
-9. `admin-mcp__list-agent-chats` — `hasDownvotes=true`, `limit=5`
-10. `admin-mcp__list-agent-votes` — `onlyDownvotes=true`, `limit=15`
-11. `vercel-mcp__list_agent_runs` over the window → Slack / Discord / web run split (discover eve project via `list_agent_run_projects` first).
-12. `ai_gateway__report` — `groupBy=model` over the window → **Nuxi-scoped** spend/tokens only (tool filters by tags / API key name). Asking for a `groupBy` always forces tag scoping when an API key name is configured — check `scope.mode`, not `scope.matchedRows`: whenever `scope.mode` is `"tags"` and `scope.note` names an API key, that result only covers tagged traffic and can undercount the real historical total, even if `scope.matchedRows` is non-zero. Re-run with no `groupBy` for the full key-name-scoped total. If that ungrouped report is still unavailable or empty, present the tagged numbers but label them explicitly as partial (tagged traffic only) — never as the complete historical spend. If both come back empty, say spend is not attributable yet — **never** quote account-wide / other-product totals (no fable, no team-wide $).
-13. `ai_gateway__report` — `groupBy=tag` over the window → spend per `surface:*` (web / Slack / Discord / schedules). Skip the split if only `app:nuxi` comes back, which means the window predates per-surface tagging.
+10. `admin-mcp__agent-usage-stats` — web chat counts and vote quality
+11. `admin-mcp__list-agent-chats` — `hasDownvotes=true`, `limit=5`
+12. `admin-mcp__list-agent-votes` — `onlyDownvotes=true`, `limit=15`
+13. `vercel-mcp__list_agent_runs` over the window → Slack / Discord / web run split (discover eve project via `list_agent_run_projects` first).
+14. `ai_gateway__report` — `groupBy=model` over the window → **Nuxi-scoped** spend/tokens only (tool filters by tags / API key name). Asking for a `groupBy` always forces tag scoping when an API key name is configured — check `scope.mode`, not `scope.matchedRows`: whenever `scope.mode` is `"tags"` and `scope.note` names an API key, that result only covers tagged traffic and can undercount the real historical total, even if `scope.matchedRows` is non-zero. Re-run with no `groupBy` for the full key-name-scoped total. If that ungrouped report is still unavailable or empty, present the tagged numbers but label them explicitly as partial (tagged traffic only) — never as the complete historical spend. If both come back empty, say spend is not attributable yet — **never** quote account-wide / other-product totals (no fable, no team-wide $).
+15. `ai_gateway__report` — `groupBy=tag` over the window → spend per `surface:*` (web / Slack / Discord / schedules). Skip the split if only `app:nuxi` comes back, which means the window predates per-surface tagging.
 
 **Link cheat sheet** (use real paths/ids from tool output):
 
@@ -66,6 +70,11 @@ AI agent:
 • Worst: <https://nuxt.com/docs/…|Installation> — 1,800 visits, "missing existing-project guide"
 • Recurring: hydration mismatch docs unclear (3 mentions)
 
+:wrench: **MCP feedback**
+• *5 agent reports* — top tool: `get-documentation-page` (3)
+• Example: Installation page omitted existing-project section — suggested: include that h2 in returned markdown
+• (If zero: *No MCP agent feedback this week*)
+
 :robot_face: **AI agent**
 • *Web chats* — 178 sessions, 114 users, 4 up / 1 down — <https://nuxt.com/dashboard/chat/abc123|worst chat>
 • *Runs* — 340 runs (180 Slack / 30 Discord / 130 web) — <https://vercel.com/nuxt-js/nuxt/observability/agent-runs|Agent Runs>
@@ -74,15 +83,15 @@ AI agent:
 
 :hammer_and_wrench: **Fix this week** (numbered — owner · action · link)
 1. :red_circle: *docs* — add "existing project" section to Installation (1,800 visits) — <https://nuxt.com/docs/…|page>
-2. :large_yellow_circle: *Nuxi* — fix module routing edge case — <https://nuxt.com/dashboard/chat/abc123|chat>
+2. :large_yellow_circle: *MCP* — fix get-documentation-page section omission — agent report
 3. :large_green_circle: *infra* — confirm WoW traffic dip is seasonal — <https://vercel.com/nuxt-js/nuxt/analytics|analytics>
 
 Rules:
 - If a section has zero data, say so in one bullet with a likely cause — do not skip the section.
 - **Fix this week** must have exactly 3 items when there is anything to improve; if truly quiet, 1–2 items with ":large_green_circle: *all clear*" is fine.
-- Rank **Fix this week** by traffic × bad feedback (and agent quality issues) — a bad score on a high-traffic page outranks the same score on a rarely-visited one.
+- Rank **Fix this week** by traffic × bad feedback (and agent quality / MCP feedback issues) — a bad score on a high-traffic page outranks the same score on a rarely-visited one.
 - Never list a page or chat without its `<url|label>` link.
 - Never invent traffic, run, or cost numbers — if a tool call fails or returns nothing attributable, say so instead of guessing.
-- Do not duplicate the same page in both **Docs feedback** and **Fix this week** as a long write-up; feedback states the problem, Fix this week owns the action.
+- Do not duplicate the same page in both **Docs feedback** / **MCP feedback** and **Fix this week** as a long write-up; feedback states the problem, Fix this week owns the action.
 
 <!-- Format aligned with server/mcp/prompts/admin/weekly-digest.ts for Cursor/IDE admin MCP. -->

--- a/layers/nuxi/server/utils/internal-api.ts
+++ b/layers/nuxi/server/utils/internal-api.ts
@@ -8,6 +8,14 @@ function safeBearerMatch(provided: string, expected: string): boolean {
   return timingSafeEqual(a, b)
 }
 
+/** Non-throwing variant, for public endpoints that only need to know the caller. */
+export function isInternalRequest(event: H3Event): boolean {
+  const secret = process.env.INTERNAL_API_SECRET?.trim()
+  if (!secret) return false
+
+  return safeBearerMatch(getRequestHeader(event, 'authorization') ?? '', `Bearer ${secret}`)
+}
+
 export function requireInternalRequest(event: H3Event) {
   const secret = process.env.INTERNAL_API_SECRET?.trim()
 

--- a/server/api/feedback/index.post.ts
+++ b/server/api/feedback/index.post.ts
@@ -1,37 +1,10 @@
 import type { H3Event } from 'h3'
 
-export async function generateHash(
-  today: string,
-  ip: string,
-  domain: string,
-  userAgent: string
-): Promise<string> {
-  const data = `${today}+${domain}+${ip}+${userAgent}`
-
-  const buffer = await crypto.subtle.digest(
-    'SHA-1',
-    new TextEncoder().encode(data)
-  )
-
-  return [...new Uint8Array(buffer)]
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('')
-}
-
-async function getFingerprint(event: H3Event): Promise<string> {
-  const ip = event.context.cf?.ip || 'unknown'
-  const userAgent = getHeader(event, 'user-agent') || 'unknown'
-  const domain = getHeader(event, 'host') || 'localhost'
-  const today = new Date().toISOString().split('T')[0]!
-
-  return generateHash(today, ip, domain, userAgent)
-}
-
 export default defineEventHandler(async (event: H3Event) => {
   const data: FeedbackInput = await readValidatedBody(event, feedbackSchema.parse)
 
   const country = event.context.cf?.country || 'unknown'
-  const fingerprint = await getFingerprint(event)
+  const fingerprint = await getFeedbackFingerprint(event)
 
   await db.insert(schema.feedback).values({
     rating: data.rating,

--- a/server/db/migrations/sqlite/0007_nifty_nocturne.sql
+++ b/server/db/migrations/sqlite/0007_nifty_nocturne.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `mcp_feedback` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`tool_name` text,
+	`feedback` text NOT NULL,
+	`suggested_fix` text,
+	`path` text,
+	`source` text DEFAULT 'mcp' NOT NULL,
+	`fingerprint` text NOT NULL,
+	`country` text NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `mcp_feedback_created_at_idx` ON `mcp_feedback` (`created_at`);--> statement-breakpoint
+CREATE INDEX `mcp_feedback_fingerprint_idx` ON `mcp_feedback` (`fingerprint`);--> statement-breakpoint
+CREATE INDEX `mcp_feedback_source_idx` ON `mcp_feedback` (`source`,`created_at`);--> statement-breakpoint
+CREATE TABLE `mcp_feedback_daily_usage` (
+	`fingerprint` text NOT NULL,
+	`day_key` text NOT NULL,
+	`count` integer DEFAULT 0 NOT NULL,
+	PRIMARY KEY(`fingerprint`, `day_key`)
+);

--- a/server/db/migrations/sqlite/meta/0007_snapshot.json
+++ b/server/db/migrations/sqlite/meta/0007_snapshot.json
@@ -1,0 +1,654 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "65d377d1-5e8f-43b2-9b0f-9f967c52d5a4",
+  "prevId": "32b374b1-bc98-4aea-8d55-2f6ad03184bd",
+  "tables": {
+    "agent_daily_usage": {
+      "name": "agent_daily_usage",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_key": {
+          "name": "day_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "limit_override": {
+          "name": "limit_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_daily_usage_day_key_idx": {
+          "name": "agent_daily_usage_day_key_idx",
+          "columns": [
+            "day_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_daily_usage_user_id_day_key_pk": {
+          "columns": [
+            "user_id",
+            "day_key"
+          ],
+          "name": "agent_daily_usage_user_id_day_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "parent_chat_id": {
+          "name": "parent_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chats_user_id_idx": {
+          "name": "chats_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "chats_parent_chat_id_idx": {
+          "name": "chats_parent_chat_id_idx",
+          "columns": [
+            "parent_chat_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_users_id_fk": {
+          "name": "chats_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_parent_chat_id_chats_id_fk": {
+          "name": "chats_parent_chat_id_chats_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "parent_chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stem": {
+          "name": "stem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "path_fingerprint_idx": {
+          "name": "path_fingerprint_idx",
+          "columns": [
+            "path",
+            "fingerprint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_feedback": {
+      "name": "mcp_feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggested_fix": {
+          "name": "suggested_fix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mcp'"
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_feedback_created_at_idx": {
+          "name": "mcp_feedback_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_feedback_fingerprint_idx": {
+          "name": "mcp_feedback_fingerprint_idx",
+          "columns": [
+            "fingerprint"
+          ],
+          "isUnique": false
+        },
+        "mcp_feedback_source_idx": {
+          "name": "mcp_feedback_source_idx",
+          "columns": [
+            "source",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_feedback_daily_usage": {
+      "name": "mcp_feedback_daily_usage",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_key": {
+          "name": "day_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "mcp_feedback_daily_usage_fingerprint_day_key_pk": {
+          "columns": [
+            "fingerprint",
+            "day_key"
+          ],
+          "name": "mcp_feedback_daily_usage_fingerprint_day_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "messages_chat_id_id_pk": {
+          "columns": [
+            "chat_id",
+            "id"
+          ],
+          "name": "messages_chat_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_provider_id_idx": {
+          "name": "users_provider_id_idx",
+          "columns": [
+            "provider",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_upvoted": {
+          "name": "is_upvoted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_chat_id_chats_id_fk": {
+          "name": "votes_chat_id_chats_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_chat_id_message_id_messages_chat_id_id_fk": {
+          "name": "votes_chat_id_message_id_messages_chat_id_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "chat_id",
+            "message_id"
+          ],
+          "columnsTo": [
+            "chat_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_chat_id_message_id_pk": {
+          "columns": [
+            "chat_id",
+            "message_id"
+          ],
+          "name": "votes_chat_id_message_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/db/migrations/sqlite/meta/_journal.json
+++ b/server/db/migrations/sqlite/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782300000000,
       "tag": "0006_drop_agent_usage_metrics",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1786356702028,
+      "tag": "0007_nifty_nocturne",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, uniqueIndex } from 'drizzle-orm/sqlite-core'
+import { sqliteTable, text, integer, index, uniqueIndex, primaryKey } from 'drizzle-orm/sqlite-core'
 
 const timestamps = {
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date())
@@ -29,3 +29,28 @@ export const feedback = sqliteTable('feedback', {
   createdAt: integer({ mode: 'timestamp' }).notNull(),
   updatedAt: integer({ mode: 'timestamp' }).notNull()
 }, table => [uniqueIndex('path_fingerprint_idx').on(table.path, table.fingerprint)])
+
+export const mcpFeedback = sqliteTable('mcp_feedback', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  toolName: text('tool_name'),
+  feedback: text('feedback').notNull(),
+  suggestedFix: text('suggested_fix'),
+  path: text('path'),
+  /** `nuxi` for the agent reporting its own gaps, `mcp` for third-party MCP clients. */
+  source: text('source', { enum: ['mcp', 'nuxi'] }).notNull().default('mcp'),
+  fingerprint: text('fingerprint').notNull(),
+  country: text('country').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date())
+}, table => [
+  index('mcp_feedback_created_at_idx').on(table.createdAt),
+  index('mcp_feedback_fingerprint_idx').on(table.fingerprint),
+  index('mcp_feedback_source_idx').on(table.source, table.createdAt)
+])
+
+export const mcpFeedbackDailyUsage = sqliteTable('mcp_feedback_daily_usage', {
+  fingerprint: text('fingerprint').notNull(),
+  dayKey: text('day_key').notNull(),
+  count: integer('count').notNull().default(0)
+}, table => [
+  primaryKey({ columns: [table.fingerprint, table.dayKey] })
+])

--- a/server/mcp/admin.ts
+++ b/server/mcp/admin.ts
@@ -2,14 +2,15 @@ import { getMcpPrompts, getMcpTools } from '@nuxtjs/mcp-toolkit/server'
 
 export default defineMcpHandler({
   name: 'admin',
-  description: 'Authenticated MCP handler for the Nuxt team to query feedback, agent chats, and votes from the production database.',
+  description: 'Authenticated MCP handler for the Nuxt team to query docs feedback, agent MCP feedback, chats, and votes from the production database.',
   icons: [
     { src: 'https://nuxt.com/icon.png', mimeType: 'image/png', sizes: ['64x64'] }
   ],
-  instructions: `You are connected to the Nuxt admin MCP. You can query docs feedback, saved web chat sessions, and per-message votes from the production database.
+  instructions: `You are connected to the Nuxt admin MCP. You can query docs feedback, agent-reported MCP feedback, saved web chat sessions, and per-message votes from the production database.
 
 Tools:
-- Feedback: \`feedback-stats\`, \`list-feedback\`
+- Docs feedback: \`feedback-stats\`, \`list-feedback\`
+- MCP agent feedback: \`mcp-feedback-stats\`, \`list-mcp-feedback\`
 - Agent quality: \`agent-usage-stats\` (web chats + votes only), \`list-agent-chats\`, \`get-agent-chat\`, \`list-agent-votes\`
 
 **Usage, tokens, cost, duration, and Slack runs** are in Vercel Observability → Agent Runs (nuxt project). Never report token/cost numbers from local DB — they are stale or absent post-Eve.

--- a/server/mcp/prompts/admin/summarize-feedback.ts
+++ b/server/mcp/prompts/admin/summarize-feedback.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export default defineMcpPrompt({
-  description: 'Summarize user feedback on the docs over a recent window: rating distribution, worst pages, and recurring themes from negative comments.',
+  description: 'Summarize user docs feedback and agent MCP feedback over a recent window: rating distribution, worst pages, MCP tool reports, and recurring themes.',
   inputSchema: {
     sinceDays: z.number().int().min(1).max(365).default(7).describe('How many days back to summarize (default 7).'),
     pathContains: z.string().optional().describe('Optional substring to focus on a specific docs section (e.g. "/docs/4.x", "data-fetching").')
@@ -10,18 +10,21 @@ export default defineMcpPrompt({
   handler({ sinceDays, pathContains }) {
     const scope = pathContains ? ` for pages matching "${pathContains}"` : ''
 
-    return `Summarize Nuxt docs user feedback from the last ${sinceDays} days${scope}.
+    return `Summarize Nuxt docs user feedback and MCP agent feedback from the last ${sinceDays} days${scope}.
 
 Steps to follow:
 1. Call \`feedback-stats\` with \`sinceDays=${sinceDays}\` (and \`topPages=10\`) to get the rating distribution and the worst-scoring pages.
 2. Call \`list-feedback\` with \`ratings=["not-helpful", "confusing"]\`, \`sinceDays=${sinceDays}\`${pathContains ? `, and \`pathContains="${pathContains}"\`` : ''}, \`limit=50\` to read the actual negative comments.
 3. If a specific page stands out in step 1, call \`list-feedback\` again with \`sinceDays=${sinceDays}\` and \`pathContains\` set to that page to read what users say about it.
+4. Call \`mcp-feedback-stats\` with \`sinceDays=${sinceDays}\` for agent-reported MCP / docs issues.
+5. Call \`list-mcp-feedback\` with \`sinceDays=${sinceDays}\`${pathContains ? `, \`pathContains="${pathContains}"\`,` : ''} \`limit=30\` to read concrete agent reports.
 
 Then produce a concise report with:
 - **Overall health**: total feedbacks, positive %, average score, week-over-week trend if you have a comparison.
 - **Worst pages** (top 5): title, URL, negative ratio, and 1-2 representative quotes.
 - **Recurring themes** in negative feedback: group similar complaints (clarity, missing examples, broken code, outdated info, etc.) with counts and example quotes.
-- **Suggested actions** the docs team should consider, prioritized by impact.
+- **MCP agent feedback**: total reports, top tools/paths, and 2–3 representative agent reports (include suggested fixes when present).
+- **Suggested actions** the docs / MCP team should consider, prioritized by impact.
 
 Always include direct links (\`https://nuxt.com<path>\`) so the team can drill down. Keep it skimmable — bullet points and short paragraphs.`
   }

--- a/server/mcp/prompts/admin/weekly-digest.ts
+++ b/server/mcp/prompts/admin/weekly-digest.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export default defineMcpPrompt({
-  description: 'Generate the Nuxt Monday digest — traffic, docs feedback, AI agent quality, and prioritized follow-ups.',
+  description: 'Generate the Nuxt Monday digest — traffic, docs feedback, MCP agent feedback, AI agent quality, and prioritized follow-ups.',
   inputSchema: {
     sinceDays: z.number().int().min(1).max(60).default(7).describe('Window in days (default 7).')
   },
@@ -14,10 +14,12 @@ Steps to follow (run them in parallel where possible):
 2. \`feedback-stats\` with \`sinceDays=${sinceDays}\`, \`topPages=5\`.
 3. \`list-feedback\` with \`ratings=["not-helpful", "confusing"]\`, \`sinceDays=${sinceDays}\`, \`limit=30\`.
 4. For worst feedback pages, weigh by real visit counts from step 1.
-5. \`agent-usage-stats\` with \`sinceDays=${sinceDays}\`.
-6. \`list-agent-chats\` with \`sinceDays=${sinceDays}\`, \`hasDownvotes=true\`, \`limit=5\`.
-7. \`list-agent-votes\` with \`onlyDownvotes=true\`, \`sinceDays=${sinceDays}\`, \`limit=15\`.
-8. Agent runs (Slack / Discord / web) and Nuxi-scoped AI Gateway spend if available — never quote account-wide / other-product totals.
+5. \`mcp-feedback-stats\` with \`sinceDays=${sinceDays}\`.
+6. \`list-mcp-feedback\` with \`sinceDays=${sinceDays}\`, \`limit=20\`.
+7. \`agent-usage-stats\` with \`sinceDays=${sinceDays}\`.
+8. \`list-agent-chats\` with \`sinceDays=${sinceDays}\`, \`hasDownvotes=true\`, \`limit=5\`.
+9. \`list-agent-votes\` with \`onlyDownvotes=true\`, \`sinceDays=${sinceDays}\`, \`limit=15\`.
+10. Agent runs (Slack / Discord / web) and Nuxi-scoped AI Gateway spend if available — never quote account-wide / other-product totals.
 
 Then write a digest in Markdown with these sections (be concise — each section ≤ 8 bullets):
 
@@ -39,13 +41,18 @@ Then write a digest in Markdown with these sections (be concise — each section
 - Worst pages (title + URL + score + traffic + 1-line takeaway).
 - Recurring complaints across negative comments.
 
+## MCP feedback
+- Total agent reports via \`report-feedback\`; top tools / paths.
+- 2–3 concrete reports (what failed + suggested fix when present).
+- If zero, say so in one line.
+
 ## AI agent
 - Web chat quality (votes, worst chats with links).
 - Runs Slack / Discord / web — [Agent Runs](https://vercel.com/nuxt-js/nuxt/observability/agent-runs).
 - Nuxi-scoped spend/tokens only — [AI Gateway](https://vercel.com/nuxt-js/nuxt/ai-gateway). If not attributable, say so; never invent or use team-wide numbers.
 
 ## Fix this week
-- 3 prioritized actions (traffic × feedback × agent), with owner suggestion and links.
+- 3 prioritized actions (traffic × docs feedback × MCP feedback × agent), with owner suggestion and links.
 
 Always include direct links so a reader can jump straight to the source. Prefer short paragraphs and bullet points; this is a digest, not a thesis.`
   }

--- a/server/mcp/tools/admin/list-mcp-feedback.ts
+++ b/server/mcp/tools/admin/list-mcp-feedback.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod'
+import { and, desc, eq, gte, like, type SQL } from 'drizzle-orm'
+
+export default defineMcpTool({
+  description: `Lists agent-reported MCP / docs feedback from the public report-feedback tool.
+
+WHEN TO USE: Review what AI agents reported about Nuxt MCP tools or documentation (errors, outdated content, missing info). Pair with \`mcp-feedback-stats\` for aggregates, then drill down here.
+
+SOURCES: \`nuxi\` is Nuxi reporting gaps it hit while answering users on nuxt.com/Slack/Discord; \`mcp\` is third-party agents using the public MCP server. Filter with \`source\` when you only care about one.
+
+OUTPUT: Rows ordered by most recent first (id, source, toolName, feedback, suggestedFix, path, country, createdAt).`,
+  inputSchema: {
+    source: z.enum(['mcp', 'nuxi']).optional().describe('Only include reports from this source (nuxi = the Nuxi agent itself, mcp = third-party MCP clients).'),
+    toolName: z.string().optional().describe('Exact MCP tool name to filter on (e.g. get-documentation-page).'),
+    pathContains: z.string().optional().describe('Substring match on the related path (e.g. "data-fetching", "/docs/4.x").'),
+    sinceDays: z.number().int().min(1).max(365).optional().describe('Only include feedback from the last N days.'),
+    limit: z.number().int().min(1).max(200).default(50).describe('Maximum number of rows to return (default 50, max 200).'),
+    offset: z.number().int().min(0).default(0).describe('Pagination offset.')
+  },
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: false
+  },
+  inputExamples: [
+    { sinceDays: 7, limit: 30 },
+    { source: 'nuxi', sinceDays: 7 },
+    { toolName: 'get-documentation-page', sinceDays: 30 }
+  ],
+  enabled: event => isMcpAdmin(event),
+  async handler({ source, toolName, pathContains, sinceDays, limit, offset }) {
+    const filters: SQL[] = []
+    if (source) filters.push(eq(schema.mcpFeedback.source, source))
+    if (toolName) filters.push(eq(schema.mcpFeedback.toolName, toolName))
+    if (pathContains) filters.push(like(schema.mcpFeedback.path, `%${pathContains}%`))
+    if (sinceDays) {
+      const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000)
+      filters.push(gte(schema.mcpFeedback.createdAt, since))
+    }
+
+    type Row = Pick<McpFeedback, 'id' | 'source' | 'toolName' | 'feedback' | 'suggestedFix' | 'path' | 'country' | 'createdAt'>
+
+    const rows: Row[] = await db
+      .select({
+        id: schema.mcpFeedback.id,
+        source: schema.mcpFeedback.source,
+        toolName: schema.mcpFeedback.toolName,
+        feedback: schema.mcpFeedback.feedback,
+        suggestedFix: schema.mcpFeedback.suggestedFix,
+        path: schema.mcpFeedback.path,
+        country: schema.mcpFeedback.country,
+        createdAt: schema.mcpFeedback.createdAt
+      })
+      .from(schema.mcpFeedback)
+      .where(filters.length ? and(...filters) : undefined)
+      .orderBy(desc(schema.mcpFeedback.createdAt))
+      .limit(limit)
+      .offset(offset)
+
+    return {
+      total: rows.length,
+      offset,
+      limit,
+      rows: rows.map((r: Row) => ({
+        ...r,
+        createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : r.createdAt,
+        url: r.path ? `https://nuxt.com${r.path}` : undefined
+      }))
+    }
+  }
+})

--- a/server/mcp/tools/admin/mcp-feedback-stats.ts
+++ b/server/mcp/tools/admin/mcp-feedback-stats.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod'
+import { and, count, desc, eq, gte, isNotNull, isNull, ne, type SQL } from 'drizzle-orm'
+
+export default defineMcpTool({
+  description: `Aggregated MCP agent feedback: total reports in a window, breakdown by source and tool, and top paths mentioned.
+
+WHEN TO USE: Start here for a high-level read on what agents report about the Nuxt MCP / docs, then drill down with \`list-mcp-feedback\`.
+
+SOURCES: \`nuxi\` is Nuxi reporting gaps it hit while answering users; \`mcp\` is third-party agents using the public MCP server. \`bySource\` always reports both; pass \`source\` to scope every other figure to one of them.
+
+OUTPUT: Window metadata, totals, per-source counts, top tools, and top paths (sorted by count descending).`,
+  inputSchema: {
+    source: z.enum(['mcp', 'nuxi']).optional().describe('Scope totals, top tools and top paths to a single source (bySource stays global).'),
+    sinceDays: z.number().int().min(1).max(365).default(30).describe('Window in days from now (default 30).'),
+    topTools: z.number().int().min(1).max(50).default(10).describe('How many top tools to return.'),
+    topPaths: z.number().int().min(1).max(50).default(10).describe('How many top paths to return.')
+  },
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: false
+  },
+  inputExamples: [
+    { sinceDays: 7 },
+    { source: 'nuxi', sinceDays: 7 },
+    { sinceDays: 30, topTools: 15 }
+  ],
+  enabled: event => isMcpAdmin(event),
+  async handler({ source, sinceDays, topTools, topPaths }) {
+    const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000)
+
+    type CountRow = { key: string, count: number }
+
+    /** Every figure but `bySource` honours the optional source filter. */
+    const scoped = (...extra: SQL[]) => and(
+      gte(schema.mcpFeedback.createdAt, since),
+      ...(source ? [eq(schema.mcpFeedback.source, source)] : []),
+      ...extra
+    )
+
+    const [
+      totalRow,
+      bySource,
+      byTool,
+      byPath,
+      withSuggestionsRow,
+      missingToolNameRow,
+      missingPathRow
+    ] = await Promise.all([
+      db
+        .select({ total: count() })
+        .from(schema.mcpFeedback)
+        .where(scoped())
+        .then(rows => rows[0]),
+      db
+        .select({
+          key: schema.mcpFeedback.source,
+          count: count()
+        })
+        .from(schema.mcpFeedback)
+        .where(gte(schema.mcpFeedback.createdAt, since))
+        .groupBy(schema.mcpFeedback.source)
+        .orderBy(desc(count())) as Promise<CountRow[]>,
+      db
+        .select({
+          key: schema.mcpFeedback.toolName,
+          count: count()
+        })
+        .from(schema.mcpFeedback)
+        .where(scoped(isNotNull(schema.mcpFeedback.toolName)))
+        .groupBy(schema.mcpFeedback.toolName)
+        .orderBy(desc(count()))
+        .limit(topTools) as Promise<CountRow[]>,
+      db
+        .select({
+          key: schema.mcpFeedback.path,
+          count: count()
+        })
+        .from(schema.mcpFeedback)
+        .where(scoped(isNotNull(schema.mcpFeedback.path)))
+        .groupBy(schema.mcpFeedback.path)
+        .orderBy(desc(count()))
+        .limit(topPaths) as Promise<CountRow[]>,
+      db
+        .select({ total: count() })
+        .from(schema.mcpFeedback)
+        .where(scoped(
+          isNotNull(schema.mcpFeedback.suggestedFix),
+          ne(schema.mcpFeedback.suggestedFix, '')
+        ))
+        .then(rows => rows[0]),
+      db
+        .select({ total: count() })
+        .from(schema.mcpFeedback)
+        .where(scoped(isNull(schema.mcpFeedback.toolName)))
+        .then(rows => rows[0]),
+      db
+        .select({ total: count() })
+        .from(schema.mcpFeedback)
+        .where(scoped(isNull(schema.mcpFeedback.path)))
+        .then(rows => rows[0])
+    ])
+
+    return {
+      window: { sinceDays, since: since.toISOString(), source: source ?? 'all' },
+      global: {
+        total: totalRow?.total ?? 0,
+        withSuggestedFix: withSuggestionsRow?.total ?? 0
+      },
+      bySource: bySource.map((r: CountRow) => ({ source: r.key, count: r.count })),
+      topTools: byTool.map((r: CountRow) => ({ toolName: r.key, count: r.count })),
+      topPaths: byPath.map((r: CountRow) => ({
+        path: r.key,
+        count: r.count,
+        url: `https://nuxt.com${r.key}`
+      })),
+      uncategorized: {
+        missingToolName: missingToolNameRow?.total ?? 0,
+        missingPath: missingPathRow?.total ?? 0
+      }
+    }
+  }
+})

--- a/server/mcp/tools/feedback/report-feedback.ts
+++ b/server/mcp/tools/feedback/report-feedback.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod'
+
+export default defineMcpTool({
+  description: `Report feedback or issues with Nuxt MCP tools or documentation.
+
+WHEN TO USE: Call this when you encounter errors, wrong or outdated content, hallucinated or mismatched docs vs actual Nuxt behavior, missing information, or a tool that returned unusable results. Prefer concrete reports (what you tried, what you expected, what you got) over vague complaints.
+
+WHEN NOT TO USE: Do not use for general Nuxt product support unrelated to this MCP server or its docs. Do not spam repeated identical reports — this is rate-limited per caller.
+
+OUTPUT: A short acknowledgment plus the remaining daily quota.`,
+  inputSchema: {
+    toolName: z.string().max(100).optional().describe('Name of the MCP tool the feedback relates to (e.g. get-documentation-page).'),
+    feedback: z.string().trim().min(1).max(2000).describe('Detailed description of the issue or improvement suggestion (max 2000 chars).'),
+    suggestedFix: z.string().trim().max(2000).optional().describe('Optional suggestion for how to fix the tool or documentation (max 2000 chars).'),
+    path: z.string().max(300).optional().describe('Optional docs/blog path involved (e.g. /docs/4.x/getting-started/installation).')
+  },
+  annotations: {
+    readOnlyHint: false,
+    openWorldHint: false
+  },
+  inputExamples: [
+    {
+      toolName: 'get-documentation-page',
+      path: '/docs/4.x/getting-started/installation',
+      feedback: 'Page markdown omitted the existing-project install section that list-documentation-pages described.',
+      suggestedFix: 'Include the "Existing project" h2 section in the returned markdown.'
+    }
+  ],
+  async handler({ toolName, feedback, suggestedFix, path }) {
+    const event = useEvent()
+    const source: McpFeedbackSource = isInternalRequest(event) ? 'nuxi' : 'mcp'
+    const fingerprint = source === 'nuxi'
+      ? NUXI_FEEDBACK_FINGERPRINT
+      : await getFeedbackFingerprint(event)
+
+    const duplicate = await findDuplicateMcpFeedback(fingerprint, feedback, toolName, path)
+    if (duplicate) {
+      return {
+        ok: true,
+        message: 'Already reported today — thanks, no need to send it again.'
+      }
+    }
+
+    const { remaining } = await consumeMcpFeedbackRateLimit(fingerprint, mcpFeedbackDailyLimit(source))
+
+    const country = event.context.cf?.country || 'unknown'
+
+    await db.insert(schema.mcpFeedback).values({
+      toolName: toolName || null,
+      feedback,
+      suggestedFix: suggestedFix || null,
+      path: path || null,
+      source,
+      fingerprint,
+      country,
+      createdAt: new Date()
+    })
+
+    return {
+      ok: true,
+      message: 'Feedback received. Thank you — the Nuxt team will use this to improve the MCP and docs.',
+      remainingToday: remaining
+    }
+  }
+})

--- a/server/utils/feedback-fingerprint.ts
+++ b/server/utils/feedback-fingerprint.ts
@@ -1,0 +1,29 @@
+import type { H3Event } from 'h3'
+
+export async function generateFeedbackHash(
+  today: string,
+  ip: string,
+  domain: string,
+  userAgent: string
+): Promise<string> {
+  const data = `${today}+${domain}+${ip}+${userAgent}`
+
+  const buffer = await crypto.subtle.digest(
+    'SHA-1',
+    new TextEncoder().encode(data)
+  )
+
+  return [...new Uint8Array(buffer)]
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/** Daily fingerprint from request IP / UA / host (UTC date). Shared by docs + MCP feedback. */
+export async function getFeedbackFingerprint(event: H3Event): Promise<string> {
+  const ip = event.context.cf?.ip || 'unknown'
+  const userAgent = getHeader(event, 'user-agent') || 'unknown'
+  const domain = getHeader(event, 'host') || 'localhost'
+  const today = new Date().toISOString().split('T')[0]!
+
+  return generateFeedbackHash(today, ip, domain, userAgent)
+}

--- a/server/utils/mcp-feedback.ts
+++ b/server/utils/mcp-feedback.ts
@@ -1,0 +1,71 @@
+import { and, eq, gte, sql, type SQL } from 'drizzle-orm'
+
+type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0]
+
+/** Max MCP feedback reports per fingerprint per calendar day (UTC). */
+export const MCP_FEEDBACK_DAILY_LIMIT = 10
+
+/** Nuxi reports for every conversation at once, so it shares a wider quota. */
+export const NUXI_FEEDBACK_DAILY_LIMIT = 100
+
+/** Fixed key so the daily dedup collapses the same gap across conversations. */
+export const NUXI_FEEDBACK_FINGERPRINT = 'nuxi'
+
+export function mcpFeedbackDailyLimit(source: McpFeedbackSource): number {
+  return source === 'nuxi' ? NUXI_FEEDBACK_DAILY_LIMIT : MCP_FEEDBACK_DAILY_LIMIT
+}
+
+function dayKey(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/**
+ * Atomically increments the per-fingerprint daily counter and throws once the
+ * limit is exceeded. Uses the same insert-then-upsert-in-a-transaction pattern
+ * as `consumeAgentRateLimitForUser` to avoid a check-then-insert race between
+ * concurrent calls from the same fingerprint.
+ */
+export async function consumeMcpFeedbackRateLimit(fingerprint: string, limit = MCP_FEEDBACK_DAILY_LIMIT): Promise<{ used: number, remaining: number, limit: number }> {
+  const key = dayKey()
+
+  return await db.transaction(async (tx: DbTransaction) => {
+    await tx.insert(schema.mcpFeedbackDailyUsage).values({ fingerprint, dayKey: key, count: 1 })
+      .onConflictDoUpdate({
+        target: [schema.mcpFeedbackDailyUsage.fingerprint, schema.mcpFeedbackDailyUsage.dayKey],
+        set: { count: sql`${schema.mcpFeedbackDailyUsage.count} + 1` }
+      })
+
+    const [row] = await tx.select().from(schema.mcpFeedbackDailyUsage)
+      .where(and(eq(schema.mcpFeedbackDailyUsage.fingerprint, fingerprint), eq(schema.mcpFeedbackDailyUsage.dayKey, key)))
+
+    const used = row!.count
+    if (used > limit) {
+      throw createError({
+        statusCode: 429,
+        message: `Daily MCP feedback limit of ${limit} reached. Try again tomorrow.`
+      })
+    }
+    return { used, remaining: limit - used, limit }
+  })
+}
+
+/** Skip inserting (and consuming quota for) an exact repeat of the same report from the same fingerprint today. */
+export async function findDuplicateMcpFeedback(fingerprint: string, feedback: string, toolName?: string, path?: string) {
+  const startOfDay = new Date()
+  startOfDay.setUTCHours(0, 0, 0, 0)
+
+  const conditions: SQL[] = [
+    eq(schema.mcpFeedback.fingerprint, fingerprint),
+    eq(schema.mcpFeedback.feedback, feedback),
+    gte(schema.mcpFeedback.createdAt, startOfDay)
+  ]
+  if (toolName) conditions.push(eq(schema.mcpFeedback.toolName, toolName))
+  if (path) conditions.push(eq(schema.mcpFeedback.path, path))
+
+  const [existing] = await db.select({ id: schema.mcpFeedback.id })
+    .from(schema.mcpFeedback)
+    .where(and(...conditions))
+    .limit(1)
+
+  return existing
+}

--- a/shared/types/db.ts
+++ b/shared/types/db.ts
@@ -1,7 +1,11 @@
-import type { feedback, users, chats, messages, votes, agentDailyUsage } from '@nuxthub/db/schema'
+import type { feedback, mcpFeedback, users, chats, messages, votes, agentDailyUsage } from '@nuxthub/db/schema'
 
 export type Feedback = typeof feedback.$inferSelect
 export type NewFeedback = typeof feedback.$inferInsert
+
+export type McpFeedback = typeof mcpFeedback.$inferSelect
+export type NewMcpFeedback = typeof mcpFeedback.$inferInsert
+export type McpFeedbackSource = McpFeedback['source']
 
 export type User = typeof users.$inferSelect
 export type NewUser = typeof users.$inferInsert


### PR DESCRIPTION
Agents hitting the Nuxt MCP had no way to tell us when a tool misbehaved or the docs came up short, so the gaps remained invisible.

Adds a public `report-feedback` tool, rate-limited and deduplicated per caller per day, writing to a new `mcp_feedback` table. Nuxi reports through it too: the nuxt-mcp connection sends the internal secret so the server can distinguish it, and its reports land as `source: 'nuxi'` with a broader quota and a shared deduplication key, so the same gap encountered across many conversations collapses into one row. Instructions tell it to report a missing or outdated page, or a question it could not answer, silently and after replying, never a fabricated one, and never a report it did not actually make.

On the admin side, `list-mcp-feedback` and `mcp-feedback-stats` expose the reports with a source filter and a per-source breakdown.

Also stop pointing users to the internal Slack workspace when something is unavailable, the community Discord is the one they can reach.