### PR TITLE
ci: add pull request bundle reports

### DIFF
--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -1,0 +1,96 @@
+name: bundle-size-comment
+
+on:
+  workflow_run:
+    workflows:
+      - bundle-size
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download bundle report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundle-size-report
+          path: bundle-size-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Update PR comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          BUNDLE_METADATA_PATH: bundle-size-report/metadata.json
+          BUNDLE_REPORT_PATH: bundle-size-report/comment.md
+        with:
+          script: |
+            const fs = require('node:fs')
+            const marker = '<!-- nuxt.com-bundle-size-report -->'
+            const run = context.payload.workflow_run
+            const metadata = JSON.parse(fs.readFileSync(process.env.BUNDLE_METADATA_PATH, 'utf8'))
+            const prNumber = Number(metadata.prNumber)
+
+            if (!Number.isSafeInteger(prNumber) || prNumber <= 0) {
+              core.setFailed('The bundle report contains an invalid PR number.')
+              return
+            }
+
+            if (!/^[0-9a-f]{40}$/.test(metadata.headSha)) {
+              core.setFailed('The bundle report contains an invalid head SHA.')
+              return
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            })
+
+            if (pull.state !== 'open') {
+              core.info(`Skipping closed PR #${prNumber}.`)
+              return
+            }
+
+            if (pull.head.sha !== run.head_sha || metadata.headSha !== run.head_sha) {
+              core.info(`Skipping stale bundle report for PR #${prNumber}.`)
+              return
+            }
+
+            const report = fs.readFileSync(process.env.BUNDLE_REPORT_PATH, 'utf8')
+            if (Buffer.byteLength(report, 'utf8') > 60_000) {
+              core.setFailed('The bundle report is too large to post safely.')
+              return
+            }
+
+            const body = `${marker}\n${report}\n[Workflow run](${run.html_url})`
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100
+            })
+            const previous = comments.find(comment => comment.user?.type === 'Bot' && comment.body?.includes(marker))
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body
+              })
+            }

--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -17,50 +17,169 @@ jobs:
   comment:
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Download bundle report
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bundle-size-report
-          path: bundle-size-report
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-      - name: Update PR comment
+      - name: Validate triggering workflow
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          BUNDLE_METADATA_PATH: bundle-size-report/metadata.json
-          BUNDLE_REPORT_PATH: bundle-size-report/comment.md
         with:
           script: |
-            const fs = require('node:fs')
-            const marker = '<!-- nuxt.com-bundle-size-report -->'
             const run = context.payload.workflow_run
-            const metadata = JSON.parse(fs.readFileSync(process.env.BUNDLE_METADATA_PATH, 'utf8'))
-            const prNumber = Number(metadata.prNumber)
+            const shaPattern = /^[0-9a-f]{40}$/
 
-            if (!Number.isSafeInteger(prNumber) || prNumber <= 0) {
-              core.setFailed('The bundle report contains an invalid PR number.')
+            if (run.path !== '.github/workflows/bundle-size.yml') {
+              core.setFailed('The triggering workflow path is invalid.')
               return
             }
 
-            if (!/^[0-9a-f]{40}$/.test(metadata.headSha)) {
-              core.setFailed('The bundle report contains an invalid head SHA.')
+            if (!Number.isSafeInteger(run.id) || run.id <= 0 || !shaPattern.test(run.head_sha) || !Number.isSafeInteger(run.head_repository?.id) || run.head_repository.id <= 0) {
+              core.setFailed('The workflow payload contains invalid head repository metadata.')
+              return
+            }
+      - name: Resolve bundle artifact
+        id: artifact
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const run = context.payload.workflow_run
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: run.id,
+              per_page: 100
+            })
+            const matches = artifacts.filter(artifact => artifact.name === 'bundle-size-report' && !artifact.expired)
+
+            if (matches.length !== 1) {
+              core.setFailed('Expected exactly one bundle report artifact from the triggering run.')
+              return
+            }
+
+            const artifact = matches[0]
+            if (!Number.isSafeInteger(artifact.id) || artifact.id <= 0 || !Number.isSafeInteger(artifact.size_in_bytes) || artifact.size_in_bytes <= 0 || artifact.size_in_bytes > 12 * 1024 * 1024) {
+              core.setFailed('The bundle report artifact metadata is invalid or too large.')
+              return
+            }
+
+            core.setOutput('id', String(artifact.id))
+      - name: Download untrusted bundle snapshots
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.artifact.outputs.id }}
+          path: ${{ runner.temp }}/bundle-size-report
+          merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Resolve triggering pull request
+        id: pull
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          BUNDLE_CONTEXT_PATH: ${{ runner.temp }}/bundle-size-report/context.json
+        with:
+          script: |
+            const fs = require('node:fs')
+            const path = require('node:path')
+            const run = context.payload.workflow_run
+            const repository = context.payload.repository
+            const candidates = run.pull_requests || []
+            const contextPath = process.env.BUNDLE_CONTEXT_PATH
+            const shaPattern = /^[0-9a-f]{40}$/
+
+            core.setOutput('should-comment', 'false')
+
+            const artifactDirectory = path.dirname(contextPath)
+            const files = fs.readdirSync(artifactDirectory).sort()
+            if (files.length !== 3 || files[0] !== 'base.json' || files[1] !== 'context.json' || files[2] !== 'pr.json') {
+              core.setFailed('The bundle artifact contains unexpected files.')
+              return
+            }
+
+            const contextStats = fs.lstatSync(contextPath)
+            const baseStats = fs.lstatSync(path.join(artifactDirectory, 'base.json'))
+            const headStats = fs.lstatSync(path.join(artifactDirectory, 'pr.json'))
+            if (!contextStats.isFile() || contextStats.isSymbolicLink() || contextStats.size > 1_024 ||
+                !baseStats.isFile() || baseStats.isSymbolicLink() || baseStats.size > 5 * 1024 * 1024 ||
+                !headStats.isFile() || headStats.isSymbolicLink() || headStats.size > 5 * 1024 * 1024) {
+              core.setFailed('The bundle artifact does not contain bounded regular files.')
+              return
+            }
+
+            const bundleContext = JSON.parse(fs.readFileSync(contextPath, 'utf8'))
+            const contextKeys = Object.keys(bundleContext)
+            if (contextKeys.length !== 1 || contextKeys[0] !== 'prNumber' || !Number.isSafeInteger(bundleContext.prNumber) || bundleContext.prNumber <= 0) {
+              core.setFailed('The bundle context contains an invalid pull request number.')
+              return
+            }
+
+            if (candidates.length > 1 || (candidates.length === 1 && candidates[0].number !== bundleContext.prNumber)) {
+              core.setFailed('The bundle context does not match the workflow payload.')
               return
             }
 
             const { data: pull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: prNumber
+              pull_number: bundleContext.prNumber
             })
 
-            if (pull.state !== 'open') {
-              core.info(`Skipping closed PR #${prNumber}.`)
+            if (pull.state !== 'open' || pull.head.sha !== run.head_sha) {
+              core.info(`Skipping stale or closed PR #${bundleContext.prNumber}.`)
               return
             }
 
-            if (pull.head.sha !== run.head_sha || metadata.headSha !== run.head_sha) {
-              core.info(`Skipping stale bundle report for PR #${prNumber}.`)
+            if (pull.head.repo?.id !== run.head_repository.id) {
+              core.setFailed('The pull request head repository does not match the triggering workflow.')
+              return
+            }
+
+            if (pull.base.repo.id !== repository.id || pull.base.ref !== repository.default_branch || !shaPattern.test(pull.base.sha)) {
+              core.setFailed('The pull request does not target the expected default branch.')
+              return
+            }
+
+            core.setOutput('should-comment', 'true')
+            core.setOutput('number', String(bundleContext.prNumber))
+            core.setOutput('base-sha', pull.base.sha)
+            core.setOutput('head-sha', run.head_sha)
+      - name: Check out the trusted reporter
+        if: steps.pull.outputs.should-comment == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - if: steps.pull.outputs.should-comment == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: lts/-1
+      - name: Validate snapshots and render report
+        if: steps.pull.outputs.should-comment == 'true'
+        env:
+          BASE_SHA: ${{ steps.pull.outputs.base-sha }}
+          BASE_SNAPSHOT: ${{ runner.temp }}/bundle-size-report/base.json
+          HEAD_SHA: ${{ steps.pull.outputs.head-sha }}
+          HEAD_SNAPSHOT: ${{ runner.temp }}/bundle-size-report/pr.json
+          REPORT_PATH: ${{ runner.temp }}/bundle-size-comment.md
+        run: |
+          node scripts/bundle-size/report.mjs compare \
+            --base "$BASE_SNAPSHOT" \
+            --head "$HEAD_SNAPSHOT" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --output "$REPORT_PATH"
+      - name: Update PR comment
+        if: steps.pull.outputs.should-comment == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          BUNDLE_REPORT_PATH: ${{ runner.temp }}/bundle-size-comment.md
+          PR_NUMBER: ${{ steps.pull.outputs.number }}
+        with:
+          script: |
+            const fs = require('node:fs')
+            const marker = '<!-- nuxt.com-bundle-size-report -->'
+            const run = context.payload.workflow_run
+            const prNumber = Number(process.env.PR_NUMBER)
+
+            if (!Number.isSafeInteger(prNumber) || prNumber <= 0) {
+              core.setFailed('The validated pull request number is invalid.')
               return
             }
 
@@ -77,7 +196,7 @@ jobs:
               issue_number: prNumber,
               per_page: 100
             })
-            const previous = comments.find(comment => comment.user?.type === 'Bot' && comment.body?.includes(marker))
+            const previous = comments.find(comment => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker))
 
             if (previous) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -26,8 +26,8 @@ jobs:
             const run = context.payload.workflow_run
             const shaPattern = /^[0-9a-f]{40}$/
 
-            if (run.path !== '.github/workflows/bundle-size.yml') {
-              core.setFailed('The triggering workflow path is invalid.')
+            if (run.name !== 'bundle-size') {
+              core.setFailed('The triggering workflow name is invalid.')
               return
             }
 

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -45,7 +45,13 @@ jobs:
         run: ln -s .bundle-base/.nuxt .nuxt
       - name: Analyze the base bundle
         working-directory: .bundle-base
-        run: pnpm nuxt analyze --extends=../scripts/bundle-size/nuxt-layer --name=base --no-serve --logLevel=info
+        run: >-
+          pnpm --package=@nuxt/cli-nightly@3.38.0-20260726-220626-c3c9e90
+          dlx nuxt analyze
+          --extends=../scripts/bundle-size/nuxt-layer
+          --name=base
+          --no-serve
+          --logLevel=info
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           NUXT_TELEMETRY_DISABLED: 1
@@ -64,7 +70,13 @@ jobs:
       - name: Prepare the PR revision
         run: pnpm nuxt prepare
       - name: Analyze the PR bundle
-        run: pnpm nuxt analyze --extends=./scripts/bundle-size/nuxt-layer --name=pr --no-serve --logLevel=info
+        run: >-
+          pnpm --package=@nuxt/cli-nightly@3.38.0-20260726-220626-c3c9e90
+          dlx nuxt analyze
+          --extends=./scripts/bundle-size/nuxt-layer
+          --name=pr
+          --no-serve
+          --logLevel=info
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           NUXT_TELEMETRY_DISABLED: 1

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Prepare the base revision
         working-directory: .bundle-base
         run: pnpm nuxt prepare
+      - name: Link the base Nuxt metadata
+        run: ln -s .bundle-base/.nuxt .nuxt
       - name: Analyze the base bundle
         working-directory: .bundle-base
         run: pnpm nuxt analyze --extends=../scripts/bundle-size/nuxt-layer --name=base --no-serve --logLevel=info
@@ -55,6 +57,8 @@ jobs:
           --label base
           --sha ${{ github.event.pull_request.base.sha }}
           --output ${{ runner.temp }}/bundle-size/base.json
+      - name: Remove the base Nuxt metadata link
+        run: unlink .nuxt
       - name: Install PR dependencies
         run: pnpm install --frozen-lockfile
       - name: Prepare the PR revision

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install base dependencies
         working-directory: .bundle-base
         run: pnpm install --frozen-lockfile
+      - name: Prepare the base revision
+        working-directory: .bundle-base
+        run: pnpm nuxt prepare
       - name: Analyze the base bundle
         working-directory: .bundle-base
         run: pnpm nuxt analyze --extends=../scripts/bundle-size/nuxt-layer --name=base --no-serve --logLevel=info
@@ -54,6 +57,8 @@ jobs:
           --output ${{ runner.temp }}/bundle-size/base.json
       - name: Install PR dependencies
         run: pnpm install --frozen-lockfile
+      - name: Prepare the PR revision
+        run: pnpm nuxt prepare
       - name: Analyze the PR bundle
         run: pnpm nuxt analyze --extends=./scripts/bundle-size/nuxt-layer --name=pr --no-serve --logLevel=info
         env:

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -49,7 +49,6 @@ jobs:
           pnpm --package=@nuxt/cli-nightly@3.38.0-20260726-220626-c3c9e90
           dlx nuxt analyze
           --extends=../scripts/bundle-size/nuxt-layer
-          --name=base
           --no-serve
           --logLevel=info
         env:
@@ -74,7 +73,6 @@ jobs:
           pnpm --package=@nuxt/cli-nightly@3.38.0-20260726-220626-c3c9e90
           dlx nuxt analyze
           --extends=./scripts/bundle-size/nuxt-layer
-          --name=pr
           --no-serve
           --logLevel=info
         env:

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,84 @@
+name: bundle-size
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bundle-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out the PR merge
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Check out the base revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: .bundle-base
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+      - run: corepack enable
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: lts/-1
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .bundle-base/pnpm-lock.yaml
+      - name: Install base dependencies
+        working-directory: .bundle-base
+        run: pnpm install --frozen-lockfile
+      - name: Analyze the base bundle
+        working-directory: .bundle-base
+        run: pnpm nuxt analyze --extends=../scripts/bundle-size/nuxt-layer --name=base --no-serve --logLevel=info
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+          NUXT_TELEMETRY_DISABLED: 1
+      - name: Snapshot the base bundle
+        run: >-
+          node scripts/bundle-size/report.mjs snapshot
+          --root .bundle-base
+          --analyze .bundle-base/.nuxt/analyze/client.json
+          --label base
+          --sha ${{ github.event.pull_request.base.sha }}
+          --output ${{ runner.temp }}/bundle-size/base.json
+      - name: Install PR dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Analyze the PR bundle
+        run: pnpm nuxt analyze --extends=./scripts/bundle-size/nuxt-layer --name=pr --no-serve --logLevel=info
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+          NUXT_TELEMETRY_DISABLED: 1
+      - name: Snapshot the PR bundle
+        run: >-
+          node scripts/bundle-size/report.mjs snapshot
+          --root .
+          --analyze .nuxt/analyze/client.json
+          --label pr
+          --sha ${{ github.event.pull_request.head.sha }}
+          --output ${{ runner.temp }}/bundle-size/pr.json
+      - name: Compare production bundles
+        run: >-
+          node scripts/bundle-size/report.mjs compare
+          --base ${{ runner.temp }}/bundle-size/base.json
+          --head ${{ runner.temp }}/bundle-size/pr.json
+          --output ${{ runner.temp }}/bundle-size/comment.md
+          --metadata ${{ runner.temp }}/bundle-size/metadata.json
+          --pr-number ${{ github.event.pull_request.number }}
+      - name: Upload bundle report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bundle-size-report
+          path: ${{ runner.temp }}/bundle-size
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -122,13 +122,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Check out the PR merge
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: lts/-1
       - name: Download base bundle snapshot
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -139,15 +132,11 @@ jobs:
         with:
           name: bundle-size-pr
           path: ${{ runner.temp }}/bundle-size
-      - name: Compare production bundles
-        run: >-
-          node scripts/bundle-size/report.mjs compare
-          --base ${{ runner.temp }}/bundle-size/base.json
-          --head ${{ runner.temp }}/bundle-size/pr.json
-          --output ${{ runner.temp }}/bundle-size/comment.md
-          --metadata ${{ runner.temp }}/bundle-size/metadata.json
-          --pr-number ${{ github.event.pull_request.number }}
-      - name: Upload bundle report
+      - name: Write bundle context
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: printf '{"prNumber":%s}\n' "$PR_NUMBER" > "$RUNNER_TEMP/bundle-size/context.json"
+      - name: Upload bundle snapshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bundle-size-report

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -13,7 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyze:
+  analyze-base:
+    name: analyze (base)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -32,9 +33,7 @@ jobs:
         with:
           node-version: lts/-1
           cache: pnpm
-          cache-dependency-path: |
-            pnpm-lock.yaml
-            .bundle-base/pnpm-lock.yaml
+          cache-dependency-path: .bundle-base/pnpm-lock.yaml
       - name: Install base dependencies
         working-directory: .bundle-base
         run: pnpm install --frozen-lockfile
@@ -62,8 +61,29 @@ jobs:
           --label base
           --sha ${{ github.event.pull_request.base.sha }}
           --output ${{ runner.temp }}/bundle-size/base.json
-      - name: Remove the base Nuxt metadata link
-        run: unlink .nuxt
+      - name: Upload base bundle snapshot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bundle-size-base
+          path: ${{ runner.temp }}/bundle-size/base.json
+          if-no-files-found: error
+          retention-days: 1
+
+  analyze-pr:
+    name: analyze (PR)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out the PR merge
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - run: corepack enable
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: lts/-1
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install PR dependencies
         run: pnpm install --frozen-lockfile
       - name: Prepare the PR revision
@@ -86,6 +106,39 @@ jobs:
           --label pr
           --sha ${{ github.event.pull_request.head.sha }}
           --output ${{ runner.temp }}/bundle-size/pr.json
+      - name: Upload PR bundle snapshot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bundle-size-pr
+          path: ${{ runner.temp }}/bundle-size/pr.json
+          if-no-files-found: error
+          retention-days: 1
+
+  report:
+    name: analyze
+    needs:
+      - analyze-base
+      - analyze-pr
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the PR merge
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: lts/-1
+      - name: Download base bundle snapshot
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundle-size-base
+          path: ${{ runner.temp }}/bundle-size
+      - name: Download PR bundle snapshot
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundle-size-pr
+          path: ${{ runner.temp }}/bundle-size
       - name: Compare production bundles
         run: >-
           node scripts/bundle-size/report.mjs compare

--- a/scripts/bundle-size/nuxt-layer/nuxt.config.ts
+++ b/scripts/bundle-size/nuxt-layer/nuxt.config.ts
@@ -1,0 +1,13 @@
+export default defineNuxtConfig({
+  build: {
+    analyze: {
+      filename: '.nuxt/analyze/{name}.json',
+      template: 'raw-data'
+    }
+  },
+  nitro: {
+    prerender: {
+      failOnError: false
+    }
+  }
+})

--- a/scripts/bundle-size/nuxt-layer/nuxt.config.ts
+++ b/scripts/bundle-size/nuxt-layer/nuxt.config.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path'
+
 export default defineNuxtConfig({
   buildDir: '.nuxt',
   build: {
@@ -9,6 +11,11 @@ export default defineNuxtConfig({
   nitro: {
     prerender: {
       failOnError: false
+    }
+  },
+  vite: {
+    oxc: {
+      tsconfig: resolve('.nuxt/tsconfig.app.json')
     }
   }
 })

--- a/scripts/bundle-size/nuxt-layer/nuxt.config.ts
+++ b/scripts/bundle-size/nuxt-layer/nuxt.config.ts
@@ -1,14 +1,8 @@
 export default defineNuxtConfig({
-  buildDir: '.nuxt',
   build: {
     analyze: {
       filename: '.nuxt/analyze/{name}.json',
       template: 'raw-data'
-    }
-  },
-  nitro: {
-    prerender: {
-      failOnError: false
     }
   }
 })

--- a/scripts/bundle-size/nuxt-layer/nuxt.config.ts
+++ b/scripts/bundle-size/nuxt-layer/nuxt.config.ts
@@ -1,5 +1,3 @@
-import { resolve } from 'node:path'
-
 export default defineNuxtConfig({
   buildDir: '.nuxt',
   build: {
@@ -11,11 +9,6 @@ export default defineNuxtConfig({
   nitro: {
     prerender: {
       failOnError: false
-    }
-  },
-  vite: {
-    oxc: {
-      tsconfig: resolve('.nuxt/tsconfig.app.json')
     }
   }
 })

--- a/scripts/bundle-size/nuxt-layer/nuxt.config.ts
+++ b/scripts/bundle-size/nuxt-layer/nuxt.config.ts
@@ -1,4 +1,5 @@
 export default defineNuxtConfig({
+  buildDir: '.nuxt',
   build: {
     analyze: {
       filename: '.nuxt/analyze/{name}.json',

--- a/scripts/bundle-size/report.mjs
+++ b/scripts/bundle-size/report.mjs
@@ -302,10 +302,14 @@ export function compareSnapshots(base, head) {
     )
   }
 
-  lines.push(
-    '',
-    '> Initial-route values include JavaScript and CSS referenced by prerendered HTML. Module values come from Nuxt’s analyzer and are attribution estimates. This workflow is currently report-only.'
-  )
+  const notes = [
+    'Module values come from Nuxt’s analyzer and are attribution estimates.',
+    'This workflow is currently report-only.'
+  ]
+  if (routes.length > 0) {
+    notes.unshift('Initial-route values include JavaScript and CSS referenced by prerendered HTML.')
+  }
+  lines.push('', `> ${notes.join(' ')}`)
 
   return `${lines.join('\n')}\n`
 }

--- a/scripts/bundle-size/report.mjs
+++ b/scripts/bundle-size/report.mjs
@@ -263,6 +263,9 @@ function inlineCode(value) {
     .replaceAll('>', '&gt;')
     .replaceAll('@', '&#64;')
     .replaceAll('|', '&#124;')
+    .replaceAll('`', '&#96;')
+    .replaceAll('[', '&#91;')
+    .replaceAll(']', '&#93;')
     .replaceAll('\r', ' ')
     .replaceAll('\n', ' ')
   return `<code>${escaped}</code>`

--- a/scripts/bundle-size/report.mjs
+++ b/scripts/bundle-size/report.mjs
@@ -275,8 +275,8 @@ function metricRow(label, base, head) {
 function moduleRegressions(base, head) {
   const modules = new Set([...Object.keys(base.modules), ...Object.keys(head.modules)])
   return [...modules].map((id) => {
-    const baseSize = base.modules[id] || EMPTY_SIZE
-    const headSize = head.modules[id] || EMPTY_SIZE
+    const baseSize = Object.hasOwn(base.modules, id) ? base.modules[id] : EMPTY_SIZE
+    const headSize = Object.hasOwn(head.modules, id) ? head.modules[id] : EMPTY_SIZE
     return {
       id,
       base: baseSize,

--- a/scripts/bundle-size/report.mjs
+++ b/scripts/bundle-size/report.mjs
@@ -3,12 +3,6 @@ import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
 import { dirname, extname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const REPRESENTATIVE_ROUTES = [
-  '/',
-  '/docs/4.x/getting-started/introduction',
-  '/docs/5.x/getting-started/introduction'
-]
-
 const EMPTY_SIZE = Object.freeze({ raw: 0, gzip: 0, brotli: 0 })
 
 function addSizes(target, sizes) {
@@ -111,58 +105,6 @@ async function readAnalyzerModules(analyzePath, root) {
   return Object.fromEntries([...modules.entries()].sort(([a], [b]) => a.localeCompare(b)))
 }
 
-async function readFirst(paths) {
-  for (const path of paths) {
-    try {
-      return await readFile(path, 'utf8')
-    } catch (error) {
-      if (error.code !== 'ENOENT') {
-        throw error
-      }
-    }
-  }
-}
-
-async function routeSizes(route, publicDir, assets) {
-  const relativeRoute = route.replace(/^\//, '')
-  const html = await readFirst(route === '/'
-    ? [resolve(publicDir, 'index.html')]
-    : [
-        resolve(publicDir, relativeRoute, 'index.html'),
-        resolve(publicDir, `${relativeRoute}.html`)
-      ])
-
-  if (!html) {
-    return
-  }
-
-  const referencedAssets = new Set()
-  const attributePattern = /(?:href|src)=["']([^"']+)["']/g
-  for (const match of html.matchAll(attributePattern)) {
-    let pathname
-    try {
-      pathname = new URL(match[1], 'https://nuxt.com').pathname
-    } catch {
-      continue
-    }
-
-    if (!pathname.startsWith('/_nuxt/')) {
-      continue
-    }
-
-    const file = pathname.slice(1)
-    if (assets[file]?.kind === 'javascript' || assets[file]?.kind === 'css') {
-      referencedAssets.add(file)
-    }
-  }
-
-  const sizes = { ...EMPTY_SIZE }
-  for (const file of referencedAssets) {
-    addSizes(sizes, assets[file].sizes)
-  }
-  return sizes
-}
-
 export async function buildSnapshot({ root, analyzePath, label, sha }) {
   const absoluteRoot = resolve(root)
   const publicDir = resolve(absoluteRoot, '.output/public')
@@ -193,20 +135,11 @@ export async function buildSnapshot({ root, analyzePath, label, sha }) {
     addSizes(totals.all, asset.sizes)
   }
 
-  const routes = {}
-  for (const route of REPRESENTATIVE_ROUTES) {
-    const sizes = await routeSizes(route, publicDir, assets)
-    if (sizes) {
-      routes[route] = sizes
-    }
-  }
-
   return {
     schemaVersion: 1,
     label,
     sha,
     totals,
-    routes,
     assets,
     modules: await readAnalyzerModules(resolve(analyzePath), absoluteRoot)
   }
@@ -278,18 +211,6 @@ export function compareSnapshots(base, head) {
     metricRow('Total client assets', base.totals.all, head.totals.all)
   ]
 
-  const routes = Object.keys(base.routes).filter(route => head.routes[route])
-  if (routes.length > 0) {
-    lines.push(
-      '',
-      '### Initial route assets',
-      '',
-      '| Route | Base (Brotli) | PR (Brotli) | Δ Brotli | Δ gzip |',
-      '| --- | ---: | ---: | ---: | ---: |',
-      ...routes.map(route => metricRow(`\`${escapeMarkdown(route)}\``, base.routes[route], head.routes[route]))
-    )
-  }
-
   const regressions = moduleRegressions(base, head)
   if (regressions.length > 0) {
     lines.push(
@@ -302,14 +223,7 @@ export function compareSnapshots(base, head) {
     )
   }
 
-  const notes = [
-    'Module values come from Nuxt’s analyzer and are attribution estimates.',
-    'This workflow is currently report-only.'
-  ]
-  if (routes.length > 0) {
-    notes.unshift('Initial-route values include JavaScript and CSS referenced by prerendered HTML.')
-  }
-  lines.push('', `> ${notes.join(' ')}`)
+  lines.push('', '> Module values come from Nuxt’s analyzer and are attribution estimates. This workflow is currently report-only.')
 
   return `${lines.join('\n')}\n`
 }

--- a/scripts/bundle-size/report.mjs
+++ b/scripts/bundle-size/report.mjs
@@ -1,9 +1,13 @@
 import { constants, brotliCompressSync, gzipSync } from 'node:zlib'
-import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
 import { dirname, extname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const EMPTY_SIZE = Object.freeze({ raw: 0, gzip: 0, brotli: 0 })
+const SNAPSHOT_SCHEMA_VERSION = 2
+const MAX_SNAPSHOT_BYTES = 5 * 1024 * 1024
+const MAX_MODULES = 25_000
+const MAX_MODULE_ID_LENGTH = 2_048
 
 function addSizes(target, sizes) {
   target.raw += sizes.raw
@@ -136,13 +140,98 @@ export async function buildSnapshot({ root, analyzePath, label, sha }) {
   }
 
   return {
-    schemaVersion: 1,
+    schemaVersion: SNAPSHOT_SCHEMA_VERSION,
     label,
     sha,
     totals,
-    assets,
     modules: await readAnalyzerModules(resolve(analyzePath), absoluteRoot)
   }
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function validateKeys(value, expected, path) {
+  const keys = Object.keys(value).sort()
+  const sortedExpected = [...expected].sort()
+  if (keys.length !== sortedExpected.length || keys.some((key, index) => key !== sortedExpected[index])) {
+    throw new Error(`${path} contains unexpected fields`)
+  }
+}
+
+function validateSize(value, path) {
+  if (!isRecord(value)) {
+    throw new Error(`${path} must be an object`)
+  }
+  validateKeys(value, ['raw', 'gzip', 'brotli'], path)
+  for (const key of ['raw', 'gzip', 'brotli']) {
+    if (!Number.isSafeInteger(value[key]) || value[key] < 0) {
+      throw new Error(`${path}.${key} must be a non-negative safe integer`)
+    }
+  }
+}
+
+export function validateSnapshot(snapshot, { label, sha } = {}) {
+  if (!isRecord(snapshot)) {
+    throw new Error('Snapshot must be an object')
+  }
+  validateKeys(snapshot, ['schemaVersion', 'label', 'sha', 'totals', 'modules'], 'Snapshot')
+
+  if (snapshot.schemaVersion !== SNAPSHOT_SCHEMA_VERSION) {
+    throw new Error(`Unsupported snapshot schema version: ${snapshot.schemaVersion}`)
+  }
+  if (snapshot.label !== label) {
+    throw new Error(`Expected a ${label} snapshot`)
+  }
+  if (!/^[0-9a-f]{40}$/.test(snapshot.sha)) {
+    throw new Error('Snapshot SHA must be a lowercase 40-character hexadecimal string')
+  }
+  if (sha && snapshot.sha !== sha) {
+    throw new Error(`${label} snapshot SHA does not match the triggering workflow`)
+  }
+
+  if (!isRecord(snapshot.totals)) {
+    throw new Error('Snapshot totals must be an object')
+  }
+  validateKeys(snapshot.totals, ['javascript', 'css', 'other', 'all'], 'Snapshot totals')
+  for (const key of ['javascript', 'css', 'other', 'all']) {
+    validateSize(snapshot.totals[key], `Snapshot totals.${key}`)
+  }
+  for (const key of ['raw', 'gzip', 'brotli']) {
+    const sum = snapshot.totals.javascript[key] + snapshot.totals.css[key] + snapshot.totals.other[key]
+    if (snapshot.totals.all[key] !== sum) {
+      throw new Error(`Snapshot totals.all.${key} is inconsistent`)
+    }
+  }
+
+  if (!isRecord(snapshot.modules)) {
+    throw new Error('Snapshot modules must be an object')
+  }
+  const modules = Object.entries(snapshot.modules)
+  if (modules.length > MAX_MODULES) {
+    throw new Error(`Snapshot contains more than ${MAX_MODULES} modules`)
+  }
+  for (const [id, sizes] of modules) {
+    if (id.length === 0 || id.length > MAX_MODULE_ID_LENGTH || /[\p{Cc}\p{Cf}\p{Cs}]/u.test(id)) {
+      throw new Error('Snapshot contains an invalid module identifier')
+    }
+    validateSize(sizes, `Snapshot module ${JSON.stringify(id)}`)
+  }
+
+  return snapshot
+}
+
+async function readSnapshot(path, expected) {
+  const stats = await lstat(path)
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new Error('Snapshot path must be a regular file')
+  }
+  const contents = await readFile(path)
+  if (contents.byteLength > MAX_SNAPSHOT_BYTES) {
+    throw new Error(`Snapshot exceeds the ${MAX_SNAPSHOT_BYTES}-byte limit`)
+  }
+  return validateSnapshot(JSON.parse(contents.toString('utf8')), expected)
 }
 
 function formatBytes(bytes) {
@@ -167,14 +256,16 @@ function formatDelta(base, head) {
   return `${sign}${formatBytes(delta)}${percentage}`
 }
 
-function escapeMarkdown(value) {
-  return value
+function inlineCode(value) {
+  const escaped = value
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;')
     .replaceAll('@', '&#64;')
-    .replaceAll('|', '\\|')
+    .replaceAll('|', '&#124;')
+    .replaceAll('\r', ' ')
     .replaceAll('\n', ' ')
+  return `<code>${escaped}</code>`
 }
 
 function metricRow(label, base, head) {
@@ -197,7 +288,10 @@ function moduleRegressions(base, head) {
     .slice(0, 10)
 }
 
-export function compareSnapshots(base, head) {
+export function compareSnapshots(base, head, expected = {}) {
+  validateSnapshot(base, { label: 'base', sha: expected.baseSha })
+  validateSnapshot(head, { label: 'pr', sha: expected.headSha })
+
   const lines = [
     '## Production bundle',
     '',
@@ -219,7 +313,7 @@ export function compareSnapshots(base, head) {
       '',
       '| Module | Base (Brotli) | PR (Brotli) | Δ Brotli |',
       '| --- | ---: | ---: | ---: |',
-      ...regressions.map(module => `| \`${escapeMarkdown(module.id)}\` | ${formatBytes(module.base.brotli)} | ${formatBytes(module.head.brotli)} | ${formatDelta(module.base.brotli, module.head.brotli)} |`)
+      ...regressions.map(module => `| ${inlineCode(module.id)} | ${formatBytes(module.base.brotli)} | ${formatBytes(module.head.brotli)} | ${formatDelta(module.base.brotli, module.head.brotli)} |`)
     )
   }
 
@@ -276,15 +370,13 @@ async function main() {
   }
 
   if (command === 'compare') {
-    const base = JSON.parse(await readFile(required(options, 'base'), 'utf8'))
-    const head = JSON.parse(await readFile(required(options, 'head'), 'utf8'))
+    const baseSha = required(options, 'base-sha')
+    const headSha = required(options, 'head-sha')
+    const base = await readSnapshot(required(options, 'base'), { label: 'base', sha: baseSha })
+    const head = await readSnapshot(required(options, 'head'), { label: 'pr', sha: headSha })
     const output = required(options, 'output')
     await mkdir(dirname(resolve(output)), { recursive: true })
-    await writeFile(output, compareSnapshots(base, head))
-    await writeJson(required(options, 'metadata'), {
-      prNumber: Number(required(options, 'pr-number')),
-      headSha: head.sha
-    })
+    await writeFile(output, compareSnapshots(base, head, { baseSha, headSha }))
     return
   }
 

--- a/scripts/bundle-size/report.mjs
+++ b/scripts/bundle-size/report.mjs
@@ -1,0 +1,381 @@
+import { constants, brotliCompressSync, gzipSync } from 'node:zlib'
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import { dirname, extname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPRESENTATIVE_ROUTES = [
+  '/',
+  '/docs/4.x/getting-started/introduction',
+  '/docs/5.x/getting-started/introduction'
+]
+
+const EMPTY_SIZE = Object.freeze({ raw: 0, gzip: 0, brotli: 0 })
+
+function addSizes(target, sizes) {
+  target.raw += sizes.raw
+  target.gzip += sizes.gzip
+  target.brotli += sizes.brotli
+  return target
+}
+
+function compressedSizes(contents) {
+  return {
+    raw: contents.byteLength,
+    gzip: gzipSync(contents, { level: 9 }).byteLength,
+    brotli: brotliCompressSync(contents, {
+      params: {
+        [constants.BROTLI_PARAM_QUALITY]: 11
+      }
+    }).byteLength
+  }
+}
+
+async function listFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files = []
+
+  for (const entry of entries) {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...await listFiles(path))
+    } else if (entry.isFile()) {
+      files.push(path)
+    }
+  }
+
+  return files
+}
+
+function assetKind(file) {
+  const extension = extname(file)
+  if (extension === '.js' || extension === '.mjs') {
+    return 'javascript'
+  }
+  if (extension === '.css') {
+    return 'css'
+  }
+  return 'other'
+}
+
+function normalizePath(path) {
+  return path.replaceAll('\\', '/')
+}
+
+function normalizeModuleId(id, root) {
+  let normalized = normalizePath(id).replace(/^\0/, 'virtual:')
+  const normalizedRoot = `${normalizePath(resolve(root))}/`
+
+  if (normalized.startsWith(normalizedRoot)) {
+    normalized = normalized.slice(normalizedRoot.length)
+  }
+
+  const nodeModulesIndex = normalized.lastIndexOf('/node_modules/')
+  if (nodeModulesIndex !== -1) {
+    normalized = `node_modules/${normalized.slice(nodeModulesIndex + '/node_modules/'.length)}`
+  }
+
+  const pnpmMatch = normalized.match(/^node_modules\/\.pnpm\/[^/]+\/node_modules\/(.+)$/)
+  return pnpmMatch ? `node_modules/${pnpmMatch[1]}` : normalized
+}
+
+async function readAnalyzerModules(analyzePath, root) {
+  const analyzer = JSON.parse(await readFile(analyzePath, 'utf8'))
+  const modules = new Map()
+
+  for (const meta of Object.values(analyzer.nodeMetas || {})) {
+    if (typeof meta.id !== 'string') {
+      continue
+    }
+
+    const sizes = { ...EMPTY_SIZE }
+    for (const partId of Object.values(meta.moduleParts || {})) {
+      const part = analyzer.nodeParts?.[partId]
+      if (part) {
+        addSizes(sizes, {
+          raw: part.renderedLength || 0,
+          gzip: part.gzipLength || 0,
+          brotli: part.brotliLength || 0
+        })
+      }
+    }
+
+    if (sizes.raw === 0 && sizes.gzip === 0 && sizes.brotli === 0) {
+      continue
+    }
+
+    const id = normalizeModuleId(meta.id, root)
+    const existing = modules.get(id) || { ...EMPTY_SIZE }
+    modules.set(id, addSizes(existing, sizes))
+  }
+
+  return Object.fromEntries([...modules.entries()].sort(([a], [b]) => a.localeCompare(b)))
+}
+
+async function readFirst(paths) {
+  for (const path of paths) {
+    try {
+      return await readFile(path, 'utf8')
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error
+      }
+    }
+  }
+}
+
+async function routeSizes(route, publicDir, assets) {
+  const relativeRoute = route.replace(/^\//, '')
+  const html = await readFirst(route === '/'
+    ? [resolve(publicDir, 'index.html')]
+    : [
+        resolve(publicDir, relativeRoute, 'index.html'),
+        resolve(publicDir, `${relativeRoute}.html`)
+      ])
+
+  if (!html) {
+    return
+  }
+
+  const referencedAssets = new Set()
+  const attributePattern = /(?:href|src)=["']([^"']+)["']/g
+  for (const match of html.matchAll(attributePattern)) {
+    let pathname
+    try {
+      pathname = new URL(match[1], 'https://nuxt.com').pathname
+    } catch {
+      continue
+    }
+
+    if (!pathname.startsWith('/_nuxt/')) {
+      continue
+    }
+
+    const file = pathname.slice(1)
+    if (assets[file]?.kind === 'javascript' || assets[file]?.kind === 'css') {
+      referencedAssets.add(file)
+    }
+  }
+
+  const sizes = { ...EMPTY_SIZE }
+  for (const file of referencedAssets) {
+    addSizes(sizes, assets[file].sizes)
+  }
+  return sizes
+}
+
+export async function buildSnapshot({ root, analyzePath, label, sha }) {
+  const absoluteRoot = resolve(root)
+  const publicDir = resolve(absoluteRoot, '.output/public')
+  const assetDir = resolve(publicDir, '_nuxt')
+  const assets = {}
+
+  for (const path of await listFiles(assetDir)) {
+    if (path.endsWith('.map') || path.endsWith('.br') || path.endsWith('.gz')) {
+      continue
+    }
+
+    const file = normalizePath(relative(publicDir, path))
+    assets[file] = {
+      kind: assetKind(file),
+      sizes: compressedSizes(await readFile(path))
+    }
+  }
+
+  const totals = {
+    javascript: { ...EMPTY_SIZE },
+    css: { ...EMPTY_SIZE },
+    other: { ...EMPTY_SIZE },
+    all: { ...EMPTY_SIZE }
+  }
+
+  for (const asset of Object.values(assets)) {
+    addSizes(totals[asset.kind], asset.sizes)
+    addSizes(totals.all, asset.sizes)
+  }
+
+  const routes = {}
+  for (const route of REPRESENTATIVE_ROUTES) {
+    const sizes = await routeSizes(route, publicDir, assets)
+    if (sizes) {
+      routes[route] = sizes
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    label,
+    sha,
+    totals,
+    routes,
+    assets,
+    modules: await readAnalyzerModules(resolve(analyzePath), absoluteRoot)
+  }
+}
+
+function formatBytes(bytes) {
+  const absolute = Math.abs(bytes)
+  if (absolute < 1024) {
+    return `${bytes} B`
+  }
+  if (absolute < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KiB`
+  }
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`
+}
+
+function formatDelta(base, head) {
+  const delta = head - base
+  if (delta === 0) {
+    return '—'
+  }
+
+  const sign = delta > 0 ? '+' : ''
+  const percentage = base === 0 ? '' : ` (${sign}${((delta / base) * 100).toFixed(1)}%)`
+  return `${sign}${formatBytes(delta)}${percentage}`
+}
+
+function escapeMarkdown(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('@', '&#64;')
+    .replaceAll('|', '\\|')
+    .replaceAll('\n', ' ')
+}
+
+function metricRow(label, base, head) {
+  return `| ${label} | ${formatBytes(base.brotli)} | ${formatBytes(head.brotli)} | ${formatDelta(base.brotli, head.brotli)} | ${formatDelta(base.gzip, head.gzip)} |`
+}
+
+function moduleRegressions(base, head) {
+  const modules = new Set([...Object.keys(base.modules), ...Object.keys(head.modules)])
+  return [...modules].map((id) => {
+    const baseSize = base.modules[id] || EMPTY_SIZE
+    const headSize = head.modules[id] || EMPTY_SIZE
+    return {
+      id,
+      base: baseSize,
+      head: headSize,
+      delta: headSize.brotli - baseSize.brotli
+    }
+  }).filter(module => module.delta > 0)
+    .sort((a, b) => b.delta - a.delta)
+    .slice(0, 10)
+}
+
+export function compareSnapshots(base, head) {
+  const lines = [
+    '## Production bundle',
+    '',
+    `Comparing \`${base.sha.slice(0, 8)}\` with \`${head.sha.slice(0, 8)}\`. Compressed sizes are calculated from the emitted production assets.`,
+    '',
+    '| Metric | Base (Brotli) | PR (Brotli) | Δ Brotli | Δ gzip |',
+    '| --- | ---: | ---: | ---: | ---: |',
+    metricRow('Client JavaScript', base.totals.javascript, head.totals.javascript),
+    metricRow('Client CSS', base.totals.css, head.totals.css),
+    metricRow('Other client assets', base.totals.other, head.totals.other),
+    metricRow('Total client assets', base.totals.all, head.totals.all)
+  ]
+
+  const routes = Object.keys(base.routes).filter(route => head.routes[route])
+  if (routes.length > 0) {
+    lines.push(
+      '',
+      '### Initial route assets',
+      '',
+      '| Route | Base (Brotli) | PR (Brotli) | Δ Brotli | Δ gzip |',
+      '| --- | ---: | ---: | ---: | ---: |',
+      ...routes.map(route => metricRow(`\`${escapeMarkdown(route)}\``, base.routes[route], head.routes[route]))
+    )
+  }
+
+  const regressions = moduleRegressions(base, head)
+  if (regressions.length > 0) {
+    lines.push(
+      '',
+      '### Largest module increases',
+      '',
+      '| Module | Base (Brotli) | PR (Brotli) | Δ Brotli |',
+      '| --- | ---: | ---: | ---: |',
+      ...regressions.map(module => `| \`${escapeMarkdown(module.id)}\` | ${formatBytes(module.base.brotli)} | ${formatBytes(module.head.brotli)} | ${formatDelta(module.base.brotli, module.head.brotli)} |`)
+    )
+  }
+
+  lines.push(
+    '',
+    '> Initial-route values include JavaScript and CSS referenced by prerendered HTML. Module values come from Nuxt’s analyzer and are attribution estimates. This workflow is currently report-only.'
+  )
+
+  return `${lines.join('\n')}\n`
+}
+
+function parseArguments(argv) {
+  const [command, ...args] = argv
+  const options = {}
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]
+    if (!argument.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${argument}`)
+    }
+
+    const key = argument.slice(2)
+    const value = args[++index]
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for --${key}`)
+    }
+    options[key] = value
+  }
+
+  return { command, options }
+}
+
+function required(options, key) {
+  if (!options[key]) {
+    throw new Error(`Missing required option --${key}`)
+  }
+  return options[key]
+}
+
+async function writeJson(path, value) {
+  await mkdir(dirname(resolve(path)), { recursive: true })
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+async function main() {
+  const { command, options } = parseArguments(process.argv.slice(2))
+
+  if (command === 'snapshot') {
+    const snapshot = await buildSnapshot({
+      root: required(options, 'root'),
+      analyzePath: required(options, 'analyze'),
+      label: required(options, 'label'),
+      sha: required(options, 'sha')
+    })
+    await writeJson(required(options, 'output'), snapshot)
+    return
+  }
+
+  if (command === 'compare') {
+    const base = JSON.parse(await readFile(required(options, 'base'), 'utf8'))
+    const head = JSON.parse(await readFile(required(options, 'head'), 'utf8'))
+    const output = required(options, 'output')
+    await mkdir(dirname(resolve(output)), { recursive: true })
+    await writeFile(output, compareSnapshots(base, head))
+    await writeJson(required(options, 'metadata'), {
+      prNumber: Number(required(options, 'pr-number')),
+      headSha: head.sha
+    })
+    return
+  }
+
+  throw new Error('Expected the snapshot or compare command')
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/bundle-size/report.test.mjs
+++ b/scripts/bundle-size/report.test.mjs
@@ -97,3 +97,31 @@ test('validates snapshots and safely renders module identifiers', () => {
     /snapshot SHA does not match/
   )
 })
+
+test('reports PR-only module identifiers inherited by ordinary objects', () => {
+  const emptyTotals = {
+    javascript: { raw: 0, gzip: 0, brotli: 0 },
+    css: { raw: 0, gzip: 0, brotli: 0 },
+    other: { raw: 0, gzip: 0, brotli: 0 },
+    all: { raw: 0, gzip: 0, brotli: 0 }
+  }
+  const base = {
+    schemaVersion: 2,
+    label: 'base',
+    sha: 'a'.repeat(40),
+    totals: emptyTotals,
+    modules: {}
+  }
+  const head = {
+    schemaVersion: 2,
+    label: 'pr',
+    sha: 'b'.repeat(40),
+    totals: emptyTotals,
+    modules: {
+      constructor: { raw: 3, gzip: 2, brotli: 1 }
+    }
+  }
+
+  const report = compareSnapshots(base, head)
+  assert.match(report, /<code>constructor<\/code> \| 0 B \| 1 B \| \+1 B/)
+})

--- a/scripts/bundle-size/report.test.mjs
+++ b/scripts/bundle-size/report.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { after, test } from 'node:test'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { buildSnapshot, compareSnapshots } from './report.mjs'
+
+const temporaryDirectories = []
+
+after(async () => {
+  await Promise.all(temporaryDirectories.map(directory => rm(directory, { force: true, recursive: true })))
+})
+
+test('builds and compares production bundle snapshots', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'nuxt-bundle-size-'))
+  temporaryDirectories.push(root)
+
+  const publicDir = join(root, '.output/public')
+  const assetDir = join(publicDir, '_nuxt')
+  const analyzePath = join(root, '.nuxt/analyze/client.json')
+  await mkdir(assetDir, { recursive: true })
+  await mkdir(join(root, '.nuxt/analyze'), { recursive: true })
+  await writeFile(join(assetDir, 'entry.js'), 'console.log("entry")')
+  await writeFile(join(assetDir, 'entry.css'), 'body { color: green }')
+  await writeFile(join(assetDir, 'entry.js.map'), '{}')
+  await writeFile(join(publicDir, 'index.html'), '<link rel="stylesheet" href="/_nuxt/entry.css"><script src="/_nuxt/entry.js"></script>')
+  await writeFile(analyzePath, JSON.stringify({
+    nodeParts: {
+      part: {
+        renderedLength: 100,
+        gzipLength: 80,
+        brotliLength: 60
+      }
+    },
+    nodeMetas: {
+      module: {
+        id: join(root, 'node_modules/example/index.js'),
+        moduleParts: { 'entry.js': 'part' }
+      }
+    }
+  }))
+
+  const base = await buildSnapshot({ root, analyzePath, label: 'base', sha: 'a'.repeat(40) })
+  const head = structuredClone(base)
+  head.sha = 'b'.repeat(40)
+  head.totals.javascript.brotli += 10
+  head.totals.javascript.gzip += 12
+  head.totals.all.brotli += 10
+  head.totals.all.gzip += 12
+  head.modules['node_modules/example/index.js'].brotli += 10
+
+  assert.equal(base.assets['_nuxt/entry.js.map'], undefined)
+  assert.equal(base.routes['/'].raw, base.totals.javascript.raw + base.totals.css.raw)
+  assert.equal(base.modules['node_modules/example/index.js'].brotli, 60)
+
+  const report = compareSnapshots(base, head)
+  assert.match(report, /Client JavaScript/)
+  assert.match(report, /Largest module increases/)
+  assert.match(report, /report-only/)
+})

--- a/scripts/bundle-size/report.test.mjs
+++ b/scripts/bundle-size/report.test.mjs
@@ -80,13 +80,15 @@ test('validates snapshots and safely renders module identifiers', () => {
     sha: 'b'.repeat(40),
     totals,
     modules: {
-      '`</code>|@nuxt<img src=x>`': size
+      '`</code>|@nuxt<img src=x>`': size,
+      '[click me](https://evil.example/)': size
     }
   }
 
   const report = compareSnapshots(base, head, { baseSha: base.sha, headSha: head.sha })
-  assert.doesNotMatch(report, /@nuxt|<img/)
-  assert.match(report, /&lt;\/code&gt;&#124;&#64;nuxt&lt;img src=x&gt;/)
+  assert.doesNotMatch(report, /@nuxt|<img|\[click me\]/)
+  assert.match(report, /&#96;&lt;\/code&gt;&#124;&#64;nuxt&lt;img src=x&gt;&#96;/)
+  assert.match(report, /&#91;click me&#93;\(https:\/\/evil\.example\/\)/)
 
   assert.throws(
     () => validateSnapshot({ ...base, schemaVersion: 1 }, { label: 'base' }),

--- a/scripts/bundle-size/report.test.mjs
+++ b/scripts/bundle-size/report.test.mjs
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterAll, test } from 'vitest'
-import { buildSnapshot, compareSnapshots } from './report.mjs'
+import { buildSnapshot, compareSnapshots, validateSnapshot } from './report.mjs'
 
 const temporaryDirectories = []
 
@@ -41,6 +41,7 @@ test('builds and compares production bundle snapshots', async () => {
 
   const base = await buildSnapshot({ root, analyzePath, label: 'base', sha: 'a'.repeat(40) })
   const head = structuredClone(base)
+  head.label = 'pr'
   head.sha = 'b'.repeat(40)
   head.totals.javascript.brotli += 10
   head.totals.javascript.gzip += 12
@@ -48,11 +49,51 @@ test('builds and compares production bundle snapshots', async () => {
   head.totals.all.gzip += 12
   head.modules['node_modules/example/index.js'].brotli += 10
 
-  assert.equal(base.assets['_nuxt/entry.js.map'], undefined)
+  assert.equal(base.schemaVersion, 2)
+  assert.equal(base.assets, undefined)
   assert.equal(base.modules['node_modules/example/index.js'].brotli, 60)
 
   const report = compareSnapshots(base, head)
   assert.match(report, /Client JavaScript/)
   assert.match(report, /Largest module increases/)
   assert.match(report, /report-only/)
+})
+
+test('validates snapshots and safely renders module identifiers', () => {
+  const size = { raw: 1, gzip: 1, brotli: 1 }
+  const totals = {
+    javascript: { ...size },
+    css: { raw: 0, gzip: 0, brotli: 0 },
+    other: { raw: 0, gzip: 0, brotli: 0 },
+    all: { ...size }
+  }
+  const base = {
+    schemaVersion: 2,
+    label: 'base',
+    sha: 'a'.repeat(40),
+    totals,
+    modules: {}
+  }
+  const head = {
+    schemaVersion: 2,
+    label: 'pr',
+    sha: 'b'.repeat(40),
+    totals,
+    modules: {
+      '`</code>|@nuxt<img src=x>`': size
+    }
+  }
+
+  const report = compareSnapshots(base, head, { baseSha: base.sha, headSha: head.sha })
+  assert.doesNotMatch(report, /@nuxt|<img/)
+  assert.match(report, /&lt;\/code&gt;&#124;&#64;nuxt&lt;img src=x&gt;/)
+
+  assert.throws(
+    () => validateSnapshot({ ...base, schemaVersion: 1 }, { label: 'base' }),
+    /Unsupported snapshot schema version/
+  )
+  assert.throws(
+    () => compareSnapshots(base, head, { baseSha: base.sha, headSha: 'c'.repeat(40) }),
+    /snapshot SHA does not match/
+  )
 })

--- a/scripts/bundle-size/report.test.mjs
+++ b/scripts/bundle-size/report.test.mjs
@@ -1,13 +1,13 @@
 import assert from 'node:assert/strict'
-import { after, test } from 'node:test'
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { afterAll, test } from 'vitest'
 import { buildSnapshot, compareSnapshots } from './report.mjs'
 
 const temporaryDirectories = []
 
-after(async () => {
+afterAll(async () => {
   await Promise.all(temporaryDirectories.map(directory => rm(directory, { force: true, recursive: true })))
 })
 

--- a/scripts/bundle-size/report.test.mjs
+++ b/scripts/bundle-size/report.test.mjs
@@ -23,7 +23,6 @@ test('builds and compares production bundle snapshots', async () => {
   await writeFile(join(assetDir, 'entry.js'), 'console.log("entry")')
   await writeFile(join(assetDir, 'entry.css'), 'body { color: green }')
   await writeFile(join(assetDir, 'entry.js.map'), '{}')
-  await writeFile(join(publicDir, 'index.html'), '<link rel="stylesheet" href="/_nuxt/entry.css"><script src="/_nuxt/entry.js"></script>')
   await writeFile(analyzePath, JSON.stringify({
     nodeParts: {
       part: {
@@ -50,18 +49,10 @@ test('builds and compares production bundle snapshots', async () => {
   head.modules['node_modules/example/index.js'].brotli += 10
 
   assert.equal(base.assets['_nuxt/entry.js.map'], undefined)
-  assert.equal(base.routes['/'].raw, base.totals.javascript.raw + base.totals.css.raw)
   assert.equal(base.modules['node_modules/example/index.js'].brotli, 60)
 
   const report = compareSnapshots(base, head)
   assert.match(report, /Client JavaScript/)
   assert.match(report, /Largest module increases/)
   assert.match(report, /report-only/)
-
-  const reportWithoutRoutes = compareSnapshots(
-    { ...base, routes: {} },
-    { ...head, routes: {} }
-  )
-  assert.doesNotMatch(reportWithoutRoutes, /Initial route/)
-  assert.doesNotMatch(reportWithoutRoutes, /Initial-route values/)
 })

--- a/scripts/bundle-size/report.test.mjs
+++ b/scripts/bundle-size/report.test.mjs
@@ -57,4 +57,11 @@ test('builds and compares production bundle snapshots', async () => {
   assert.match(report, /Client JavaScript/)
   assert.match(report, /Largest module increases/)
   assert.match(report, /report-only/)
+
+  const reportWithoutRoutes = compareSnapshots(
+    { ...base, routes: {} },
+    { ...head, routes: {} }
+  )
+  assert.doesNotMatch(reportWithoutRoutes, /Initial route/)
+  assert.doesNotMatch(reportWithoutRoutes, /Initial-route values/)
 })


### PR DESCRIPTION
*Human written below*

## Summary

Compare production Nuxt bundle with `nuxt analyze` from the opened PR vs `main`,

Both analyses are run in parallel to save time, then we compare the snapshots generated by `nuxt analyze`.

Comment on the PR to report exact Brotli/gzip asset deltas and the largest module increases.

Currently pin `@nuxt/cli-nightly@3.38.0-20260726-220626-c3c9e90`, which includes nuxt/cli#1400 so we avoid pre-rendering (24m40s -> 10m31s) and using parallel builds made the total run around 5m!

---

*AI generated content blow*

## Security

- run fork-controlled code only in the unprivileged `pull_request` workflow with a read-only token and no secrets
- transfer only raw snapshots and a PR number; never execute or publish artifact-provided code or Markdown
- require exactly one bounded artifact containing exactly three bounded regular files
- resolve the PR through the GitHub API and bind it to the workflow's head repository/SHA, this repository, and the default branch
- validate an exact snapshot schema, size/count limits, internally consistent totals, and the expected base/head SHAs
- check out the trusted reporter from the default branch and escape analyzer-controlled module identifiers before commenting
- update only the sticky comment owned by `github-actions[bot]`

## Verification

- `scripts/bundle-size/report.test.mjs` with Vitest (2 tests, including malicious renderer input and SHA/schema rejection)
- `./node_modules/.bin/eslint scripts/bundle-size`
- YAML parsing and compilation of every embedded `actions/github-script` program
- `git diff --check`
- pinned nightly CLI help confirms prerendering is opt-in
- GitHub `lint`, `unit`, `typecheck`, CodeQL, Socket, and parallel `bundle-size` checks passed on commit `d44a0b03`
- downloaded the successful run artifact and confirmed its exact three-file allowlist, schema v2, size limits, PR context, and current base/head SHAs
- ran the trusted reporter against that artifact with the API-resolved SHAs

## Bootstrap note

The unprivileged analyzer can run on this PR. The `workflow_run` commenter becomes active after the workflow exists on the default branch.
