### PR TITLE
fix: keep content toc mounted while the agent is docked

### DIFF
--- a/app/pages/blog/[slug].vue
+++ b/app/pages/blog/[slug].vue
@@ -163,7 +163,7 @@ const links = [
         </UPageBody>
 
         <template #right>
-          <UContentToc v-if="!isAgentDocked && article.body && article.body.toc" :links="article.body.toc.links" title="Table of Contents" highlight highlight-variant="circuit">
+          <UContentToc v-if="article.body && article.body.toc" :links="article.body.toc.links" title="Table of Contents" highlight highlight-variant="circuit">
             <template #bottom>
               <div class="hidden lg:block space-y-6">
                 <UPageLinks title="Links" :links="links" />

--- a/app/pages/deploy/[slug].vue
+++ b/app/pages/deploy/[slug].vue
@@ -121,7 +121,7 @@ links.push({
         </UPageBody>
 
         <template #right>
-          <UContentToc v-if="!isAgentDocked" :links="provider.body.toc?.links || []">
+          <UContentToc :links="provider.body.toc?.links || []">
             <template #bottom>
               <div class="hidden lg:block space-y-6">
                 <USeparator v-if="links?.length && provider.body?.toc?.links?.length" type="dashed" />

--- a/app/pages/deploy/[slug].vue
+++ b/app/pages/deploy/[slug].vue
@@ -121,7 +121,7 @@ links.push({
         </UPageBody>
 
         <template #right>
-          <UContentToc :links="provider.body.toc?.links || []">
+          <UContentToc :links="provider.body?.toc?.links || []">
             <template #bottom>
               <div class="hidden lg:block space-y-6">
                 <USeparator v-if="links?.length && provider.body?.toc?.links?.length" type="dashed" />

--- a/app/pages/docs/[...slug].vue
+++ b/app/pages/docs/[...slug].vue
@@ -280,7 +280,7 @@ const noRightAside = computed(() => route.path.includes('/examples/'))
 
         <template #right>
           <ContentToc
-            v-if="!isAgentDocked && !noRightAside"
+            v-if="!noRightAside"
             :links="page.body?.toc?.links"
             :community-links="communityLinks"
             highlight

--- a/app/pages/modules/[slug].vue
+++ b/app/pages/modules/[slug].vue
@@ -222,7 +222,7 @@ if (import.meta.server) {
       </UPageBody>
 
       <template #right>
-        <UContentToc v-if="!isAgentDocked" :links="module.readme?.toc?.links">
+        <UContentToc :links="module.readme?.toc?.links">
           <template #bottom>
             <div class="hidden lg:block space-y-6">
               <UPageLinks title="Links" :links="links" />


### PR DESCRIPTION
Opening then closing nuxi killed the active highlight on the `ContentToc` circuit line until the next navigation.

`UContentToc` registers its headings through `useScrollspy` only from the `page:loading:end` and `page:transition:finish` hooks, there is no `onMounted` call. Toggling `isAgentDocked` `v-if`-destroyed the toc, so remounting it created a fresh `IntersectionObserver` observing nothing. `activeHeadings` stayed empty, `indicatorStyle` returned `undefined`, and the `indicatorActive` element was never rendered.

The `v-if` was redundant anyway, every one of these pages already sets `right: 'lg:hidden'` on the docked branch of its `:ui`, so the column is hidden either way. Dropping it keeps the toc mounted and the scrollspy alive, which is what ui.nuxt.com does.