### PR TITLE
ci: use github app token for bundle report comments

### DIFF
--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -165,9 +165,18 @@ jobs:
             --base-sha "$BASE_SHA" \
             --head-sha "$HEAD_SHA" \
             --output "$REPORT_PATH"
+      - name: Mint bundle report app token
+        if: steps.pull.outputs.should-comment == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.BUNDLE_REPORT_APP_ID }}
+          private-key: ${{ secrets.BUNDLE_REPORT_APP_PRIVATE_KEY }}
       - name: Update PR comment
         if: steps.pull.outputs.should-comment == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
         env:
           BUNDLE_REPORT_PATH: ${{ runner.temp }}/bundle-size-comment.md
           PR_NUMBER: ${{ steps.pull.outputs.number }}
@@ -190,26 +199,33 @@ jobs:
             }
 
             const body = `${marker}\n${report}\n[Workflow run](${run.html_url})`
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 100
-            })
-            const previous = comments.find(comment => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker))
 
-            if (previous) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: previous.id,
-                body
-              })
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body
+                per_page: 100
               })
+              const previous = comments.find(comment => comment.user?.login?.endsWith('[bot]') && comment.body?.includes(marker))
+
+              if (previous) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: previous.id,
+                  body
+                })
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body
+                })
+              }
+            } catch (error) {
+              core.warning(`Unable to post the bundle report comment: ${error.message}`)
+              await core.summary.addRaw(report).write()
+              core.info('The bundle report was written to the workflow run summary instead.')
             }


### PR DESCRIPTION
## Summary

Fixes the bundle report comment never appearing on fork PRs (e.g. #2383).

The `bundle-size-comment` workflow ran but failed at the last step with `403 Resource not accessible by integration`. GitHub downgrades `GITHUB_TOKEN` to read-only for run chains that start from a fork `pull_request`, so the declared `issues: write` permission is ignored.

## Changes

- Mint a GitHub App installation token (`actions/create-github-app-token`, pinned to v3.2.0) using the new `BUNDLE_REPORT_APP_ID` / `BUNDLE_REPORT_APP_PRIVATE_KEY` secrets. `workflow_run` runs have access to secrets even for fork triggers.
- Post the comment with the app token instead of `GITHUB_TOKEN`.
- Accept any `*[bot]` author when looking for a previous report comment (the app posts as `<app-slug>[bot]`).
- Fall back to the workflow run summary if the comment call fails, so the run stays green.

## Verification after merge

- Re-run the analyze workflow of #2383 (`gh run rerun 32369770229`). Its completion triggers this workflow from `main`, and the app should post the comparison comment there.

---
*Generated with an AI coding agent; changes reviewed by a human before submission.*