### PR TITLE
feat(templates): add Listory directory template

### DIFF
--- a/content/templates/listory.yml
+++ b/content/templates/listory.yml
@@ -1,0 +1,6 @@
+name: 'Listory'
+slug: 'listory'
+description: 'A static directory template. Entries are files in the repo — no database, no backend, no third-party requests at runtime.'
+badge: 'Free'
+repo: 'peppe1337/listory'
+demo: 'https://peppe1337.github.io/listory/'


### PR DESCRIPTION
Adds **Listory**, a free MIT-licensed directory template for Nuxt 4.

- Repo: https://github.com/peppe1337/listory
- Demo: https://peppe1337.github.io/listory/
- Licence: MIT

**What it is:** a statically generated directory/catalog site. Entries live in a JSON file in the repository, so there is no database, no CMS account and no server. It generates an index, a detail page per entry and a page per category, plus `sitemap.xml`, `robots.txt`, canonical URLs and JSON-LD (`ItemList` / `SoftwareApplication`).

**No third-party requests at runtime** — no analytics, no CDN, no externally loaded fonts. That is verifiable from the build output:

```
grep -roE 'https?://[a-z0-9.-]+' .output/public --include='*.html' | sed 's/.*http/http/' | sort -u
```

**Deliberately limited, and the README says so up front:** there is no submission form, no user accounts, no payments and no moderation workflow, because all four need a server. The README points readers to mkdirs and Nuxt_Mkdirs if they need those.

It is new (v0.1.0), so I understand entirely if you would rather wait until it has some traction — happy to leave this open or close it, whichever suits you. I did not run the site locally to generate the screenshot; let me know if you would like me to add one.