### PR TITLE
fix(docs): apply right aside layout classes

### DIFF
--- a/app/components/content-toc/ContentToc.vue
+++ b/app/components/content-toc/ContentToc.vue
@@ -17,6 +17,7 @@ interface PageLink {
 interface Props {
   links?: TocLink[]
   communityLinks: PageLink[]
+  drawer?: boolean
 }
 
 defineProps<Props>()
@@ -28,6 +29,7 @@ defineProps<Props>()
       <ContentTocBottom
         :has-links="!!links?.length"
         :community-links="communityLinks"
+        :drawer="drawer"
       />
     </template>
     <template v-for="(_, name) in $slots" #[name]="slotData" :key="name">

--- a/app/components/content-toc/ContentTocBottom.vue
+++ b/app/components/content-toc/ContentTocBottom.vue
@@ -16,14 +16,17 @@ interface Props {
 const props = defineProps<Props>()
 
 const route = useRoute()
-const { open, isAgentDocked } = useNuxtAgent()
+const { open, isOpen } = useNuxtAgent()
 const { track } = useAnalytics()
 
 // Carbon only renders a single ad per page, so mount it in the toc that is
 // actually visible: the drawer below `lg`, the aside above unless the agent
-// panel is docked over it.
+// panel covers it. `isOpen` is restored from local storage on nuxt ready, so
+// wait for it to settle rather than loading an ad we tear down right after.
 const isLargeScreen = useMediaQuery('(min-width: 1024px)')
-const showAds = computed(() => props.drawer ? !isLargeScreen.value : isLargeScreen.value && !isAgentDocked.value)
+const agentSettled = ref(false)
+onNuxtReady(() => nextTick(() => agentSettled.value = true))
+const showAds = computed(() => props.drawer ? !isLargeScreen.value : agentSettled.value && isLargeScreen.value && !isOpen.value)
 
 function explainWithAI() {
   track('Nuxi Explain Page', { page: route.path })

--- a/app/components/content-toc/ContentTocBottom.vue
+++ b/app/components/content-toc/ContentTocBottom.vue
@@ -16,13 +16,14 @@ interface Props {
 const props = defineProps<Props>()
 
 const route = useRoute()
-const { open } = useNuxtAgent()
+const { open, isAgentDocked } = useNuxtAgent()
 const { track } = useAnalytics()
 
 // Carbon only renders a single ad per page, so mount it in the toc that is
-// actually visible: the drawer below `lg`, the aside above.
+// actually visible: the drawer below `lg`, the aside above unless the agent
+// panel is docked over it.
 const isLargeScreen = useMediaQuery('(min-width: 1024px)')
-const showAds = computed(() => props.drawer ? !isLargeScreen.value : isLargeScreen.value)
+const showAds = computed(() => props.drawer ? !isLargeScreen.value : isLargeScreen.value && !isAgentDocked.value)
 
 function explainWithAI() {
   track('Nuxi Explain Page', { page: route.path })

--- a/app/components/content-toc/ContentTocBottom.vue
+++ b/app/components/content-toc/ContentTocBottom.vue
@@ -10,13 +10,19 @@ interface PageLink {
 interface Props {
   hasLinks?: boolean
   communityLinks: PageLink[]
+  drawer?: boolean
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
 
 const route = useRoute()
 const { open } = useNuxtAgent()
 const { track } = useAnalytics()
+
+// Carbon only renders a single ad per page, so mount it in the toc that is
+// actually visible: the drawer below `lg`, the aside above.
+const isLargeScreen = useMediaQuery('(min-width: 1024px)')
+const showAds = computed(() => props.drawer ? !isLargeScreen.value : isLargeScreen.value)
 
 function explainWithAI() {
   track('Nuxi Explain Page', { page: route.path })
@@ -37,5 +43,5 @@ function explainWithAI() {
   />
   <USeparator type="dashed" />
   <SocialLinks />
-  <Ads />
+  <Ads v-if="showAds" />
 </template>

--- a/app/pages/docs/[...slug].vue
+++ b/app/pages/docs/[...slug].vue
@@ -193,6 +193,76 @@ const noRightAside = computed(() => route.path.includes('/examples/'))
 <template>
   <UContainer v-if="page">
     <DocsVersionAlert />
+    <!-- mobile -->
+    <div class="lg:hidden sticky top-(--ui-header-height) z-10 bg-default/75 backdrop-blur -mx-4 sm:-mx-6 p-6 border-b border-dashed border-default flex justify-between">
+      <UDrawer
+        v-model:open="menuDrawerOpen"
+        direction="left"
+        :title="currentSectionTitle"
+        inset
+        :handle="false"
+        side="left"
+        :ui="{
+          content: 'w-full max-w-2/3'
+        }"
+      >
+        <UButton
+          label="Menu"
+          icon="i-lucide-text-align-start"
+          color="neutral"
+          variant="link"
+          size="xs"
+          aria-label="Open navigation"
+          class="-m-4"
+        />
+        <template #body>
+          <UContentNavigation
+            :navigation="asideNavigation"
+            default-open
+            trailing-icon="i-lucide-chevron-right"
+            :ui="{ linkTrailingIcon: 'group-data-[state=open]:rotate-90' }"
+            highlight
+          />
+        </template>
+      </UDrawer>
+      <UDrawer
+        v-if="!noRightAside"
+        v-model:open="onThisPageDrawerOpen"
+        direction="right"
+        :handle="false"
+        side="right"
+        inset
+        no-body-styles
+        :ui="{
+          content: 'w-full max-w-2/3'
+        }"
+        @update:open="refreshHeading"
+      >
+        <UButton
+          label="On this page"
+          trailing-icon="i-lucide-chevron-right"
+          color="neutral"
+          variant="link"
+          size="xs"
+          aria-label="Open on this page"
+          class="-m-4"
+        />
+        <template #body>
+          <ContentToc
+            :links="page.body?.toc?.links"
+            :community-links="communityLinks"
+            :open="true"
+            default-open
+            :ui="{
+              root: '!mx-0 !px-1 top-0 overflow-visible',
+              container: '!pt-0 border-b-0',
+              trailingIcon: 'hidden',
+              bottom: 'flex flex-col'
+            }"
+          />
+        </template>
+      </UDrawer>
+    </div>
     <UPage>
       <template #left>
         <UPageAside>
@@ -204,10 +274,10 @@ const noRightAside = computed(() => route.path.includes('/examples/'))
         </UPageAside>
       </template>
       <UPage
-        :ui="isAgentDocked || noRightAside? {
+        :ui="isAgentDocked || noRightAside ? {
           center: 'lg:col-span-10',
-          right: 'lg:hidden'
-        } : { root: 'lg:grid-cols-12', center: 'lg:col-span-9', right: 'lg:col-span-3' }"
+          right: 'hidden'
+        } : { root: 'lg:grid-cols-12', center: 'lg:col-span-9', right: 'hidden lg:flex lg:col-span-3' }"
       >
         <UPageHeader
           :ui="{
@@ -286,84 +356,12 @@ const noRightAside = computed(() => route.path.includes('/examples/'))
             :community-links="communityLinks"
             highlight
             highlight-variant="circuit"
-            class="hidden lg:flex lg:backdrop-blur-none lg:overflow-y-auto"
+            class="lg:backdrop-blur-none lg:overflow-y-auto"
             :ui="{
               container: 'lg:max-h-[inherit]',
               content: 'lg:min-h-[min(var(--list-height,8rem),8rem)]'
             }"
           />
-          <!-- mobile -->
-          <div class="order-first lg:order-last sticky top-(--ui-header-height) z-10 bg-default/75 lg:bg-[initial] backdrop-blur -mx-4 p-6 border-b border-dashed border-default flex justify-between">
-            <UDrawer
-              v-model:open="menuDrawerOpen"
-              direction="left"
-              :title="currentSectionTitle"
-              inset
-              :handle="false"
-              side="left"
-              class="lg:hidden"
-              :ui="{
-                content: 'w-full max-w-2/3'
-              }"
-            >
-              <UButton
-                label="Menu"
-                icon="i-lucide-text-align-start"
-                color="neutral"
-                variant="link"
-                size="xs"
-                aria-label="Open navigation"
-                class="-m-4"
-              />
-              <template #body>
-                <UContentNavigation
-                  :navigation="asideNavigation"
-                  default-open
-                  trailing-icon="i-lucide-chevron-right"
-                  :ui="{ linkTrailingIcon: 'group-data-[state=open]:rotate-90' }"
-                  highlight
-                />
-              </template>
-            </UDrawer>
-            <UDrawer
-              v-if="!noRightAside"
-              v-model:open="onThisPageDrawerOpen"
-              direction="right"
-              :handle="false"
-              side="right"
-              inset
-              class="lg:hidden"
-              no-body-styles
-              :ui="{
-                content: 'w-full max-w-2/3'
-              }"
-              @update:open="refreshHeading"
-            >
-              <UButton
-                label="On this page"
-                trailing-icon="i-lucide-chevron-right"
-                color="neutral"
-                variant="link"
-                size="xs"
-                aria-label="Open on this page"
-                class="-m-4"
-              />
-              <template #body>
-                <ContentToc
-                  :links="page.body?.toc?.links"
-                  :community-links="communityLinks"
-                  :open="true"
-                  default-open
-                  :ui="{
-                    root: '!mx-0 !px-1 top-0 overflow-visible',
-                    container: '!pt-0 border-b-0',
-                    trailingIcon: 'hidden',
-                    bottom: 'flex flex-col'
-                  }"
-                />
-              </template>
-            </UDrawer>
-          </div>
         </template>
       </UPage>
     </UPage>

--- a/app/pages/docs/[...slug].vue
+++ b/app/pages/docs/[...slug].vue
@@ -253,6 +253,7 @@ const noRightAside = computed(() => route.path.includes('/examples/'))
             :community-links="communityLinks"
             :open="true"
             default-open
+            drawer
             :ui="{
               root: '!mx-0 !px-1 top-0 overflow-visible',
               container: '!pt-0 border-b-0',


### PR DESCRIPTION
The `#right` slot of `UPage` renders through reka's `Slot`, which merges the slot classes into the first non-comment child only. The docs page had two elements in there (the ToC and the mobile toolbar), so the `lg:col-span-3` / `lg:hidden` overrides never reached the toolbar, and on `/examples/*` pages the ToC is `v-if`'d out so they landed on the toolbar instead of the ToC.

- moved the mobile toolbar out of `#right` up to `UContainer` with `lg:hidden`. It keeps sticking under the header since its containing block is now the container rather than the grid root. Wrapping it together with the ToC in a single div wasn't an option, the wrapper is only as tall as the toolbar on mobile so `sticky` would do nothing.
- `#right` now only holds `ContentToc`, so the col span applies.
- moved `hidden lg:flex` off `ContentToc` into the `right` ui slot so it goes through tailwind-merge instead of colliding with the `lg:hidden` override. The docked/examples branch is now plain `hidden`, which keeps the ToC mounted and out of the grid.

While checking this I noticed the carbon ad never rendered in the `On this page` drawer on mobile. The aside `ContentToc` stays mounted below `lg` (just hidden), so it wins the `#carbonads` id and the drawer's script no-ops on an empty slot. Same story whenever the agent panel is open: docked it hides the aside outright, and between `lg` and `xl` it covers it with a slideover, so the ad loaded where nobody could see it.

`ContentTocBottom` now takes a `drawer` prop and only mounts `Ads` in the toc that is actually visible, the drawer below `lg`, the aside above unless the agent panel is open. `isOpen` is restored from local storage on nuxt ready, so the check waits for it to settle instead of loading an ad and tearing it down a tick later.

Checked on the preview:

| scenario | ad in dom | ad requests |
| --- | --- | --- |
| desktop | 1 | 2 |
| desktop, panel restored open | 0 | 0 |
| 1100px, panel restored open | 0 | 0 |
| mobile | 0 | 0 |
| mobile, drawer open | 1 | 1 |
| `/examples/*` | 0 | 0 |