### PR TITLE
fix(agents): prerender markdown twins and give the guidance its own section

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,6 @@
 import { createResolver } from 'nuxt/kit'
 import { parseMdc } from './helpers/mdc-parser.mjs'
-import { agentWhenToUse } from './shared/utils/agents'
+import { agentHowToCall, agentWhenToUse } from './shared/utils/agents'
 import { CLI_DOCS_PREFIX, CLI_DOCS_REFS, CLI_DOCS_REPO } from './shared/utils/cli-docs'
 import { CURRENT_DOCS_VERSION, EXCLUDED_DOC_VERSIONS } from './shared/utils/docs'
 
@@ -474,10 +474,15 @@ export default defineNuxtConfig({
       // `getting-started/introduction` seeds in `routeRules` (the version
       // switcher lives in a dropdown, so its links aren't in the SSR'd HTML
       // and each version tree needs its own entry point).
+      //
+      // `/raw/**` is deliberately not ignored: nuxt-agent-discovery hands the
+      // crawler each prerendered page's markdown twin, so an agent reads a
+      // static file off the CDN rather than waiting on a render. The twins the
+      // site backs with live handlers (`/raw/modules.md`, `/raw/changelog.md`)
+      // are skipped by the module itself.
       crawlLinks: true,
       ignore: [
         route => route === '/modules' || route.startsWith('/modules/'),
-        route => route.startsWith('/raw/'),
         route => route.startsWith('/admin'),
         route => route.startsWith('/login'),
         route => route.startsWith('/dashboard'),
@@ -604,9 +609,10 @@ export default defineNuxtConfig({
     },
     llms: {
       // The details section llmstxt.org reserves between the blockquote and the
-      // first `##`: what these docs are the right source for, and how to fetch
-      // them. `/raw/index.md` carries the same paragraphs under a heading.
-      details: agentWhenToUse(SITE_URL)
+      // first `##`. Orientation only: the jobs these docs answer get their own
+      // `## When to use this` section below, where a reader scanning headings
+      // will actually find them.
+      details: agentHowToCall(SITE_URL)
     },
     sitemap: {
       markdown: {
@@ -695,6 +701,13 @@ export default defineNuxtConfig({
       description: 'The complete Nuxt documentation and blog posts written in Markdown (MDC syntax).'
     },
     sections: [
+      {
+        // First, and carrying the landing page link, which is what keeps
+        // nuxt-agent-discovery from prepending an `Overview` section of its own.
+        title: 'When to use this',
+        description: agentWhenToUse().join('\n\n'),
+        links: [{ title: 'Nuxt', href: SITE_URL }]
+      },
       {
         title: 'Nuxt v5 Documentation',
         contentCollection: 'docsv5',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -609,7 +609,8 @@ export default defineNuxtConfig({
     },
     llms: {
       // The details section llmstxt.org reserves between the blockquote and the
-      // first `##`. Orientation only: the jobs these docs answer get their own
+      // first `##`, carrying how to fetch the docs: markdown negotiation, the
+      // MCP server, the OpenAPI document. The jobs they answer get their own
       // `## When to use this` section below, where a reader scanning headings
       // will actually find them.
       details: agentHowToCall(SITE_URL)

--- a/server/plugins/agent-discovery.ts
+++ b/server/plugins/agent-discovery.ts
@@ -1,6 +1,6 @@
 import { queryCollection } from '@nuxt/content/server'
 import { rawUrl, getAgentSiteUrl } from '#agent-discovery'
-import { agentWhenToUse } from '#shared/utils/agents'
+import { agentHowToCall, agentWhenToUse } from '#shared/utils/agents'
 import { CURRENT_DOCS_VERSION } from '#shared/utils/docs'
 
 export default defineNitroPlugin((nitroApp) => {
@@ -22,7 +22,10 @@ export default defineNitroPlugin((nitroApp) => {
     index.body.push(
       `## When to use this
 
-${agentWhenToUse(domain).join('\n\n')}`,
+${agentWhenToUse().join('\n\n')}`,
+      `## How to fetch these docs
+
+${agentHowToCall(domain).join('\n\n')}`,
       `## Features
 
 ${featureBullets}`,

--- a/server/plugins/llms.ts
+++ b/server/plugins/llms.ts
@@ -8,8 +8,18 @@ const TRIMMED_SECTIONS = new Set([
   'Nuxt v5 Documentation'
 ])
 
+// nuxt-llms prepends a "Documentation Sets" section for the `full` document, so
+// the guidance is pulled back to the front here: what these docs answer is what
+// an agent should read before any link list.
+const GUIDANCE_SECTION = 'When to use this'
+
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('llms:generate', (_event, options) => {
     options.sections = options.sections.filter((section: { title: string }) => !TRIMMED_SECTIONS.has(section.title))
+
+    const guidance = options.sections.findIndex((section: { title: string }) => section.title === GUIDANCE_SECTION)
+    if (guidance > 0) {
+      options.sections.unshift(...options.sections.splice(guidance, 1))
+    }
   })
 })

--- a/shared/utils/agents.ts
+++ b/shared/utils/agents.ts
@@ -1,15 +1,28 @@
-// "When to use this" guidance for agents, written once and served twice:
+// Guidance for agents, written once and served on every surface that carries it.
 //
-//   - nuxt.config.ts                    → `agentDiscovery.llms.details`, the details section of /llms.txt
-//   - server/plugins/agent-discovery.ts → the `## When to use this` section of /raw/index.md
+// Split in two because llms.txt has two homes for it: the details section, the
+// free prose llmstxt.org reserves between the blockquote and the first `##`,
+// takes the orientation; the jobs these docs are the right source for get their
+// own `## When to use this` section, so a reader scanning headings finds them.
 //
-// Kept as paragraphs rather than a formatted block because llms.txt puts free
-// prose between the blockquote and the first `## ` section, where headings are
-// not allowed (llmstxt.org). The raw index adds the heading itself.
-export function agentWhenToUse(domain: string): string[] {
+//   - nuxt.config.ts                    → `agentDiscovery.llms.details` and the `llms.sections` entry
+//   - server/plugins/agent-discovery.ts → the two sections of /raw/index.md
+//
+// Neither carries a heading of its own: the details slot forbids one, and both
+// callers add the heading that suits them.
+
+/** The jobs these docs answer, and the ones they do not. */
+export function agentWhenToUse(): string[] {
   return [
-    'Reach for these docs when you are writing, reviewing or debugging code for a Nuxt application: scaffolding a project, configuring `nuxt.config.ts`, picking a rendering mode per route, writing pages, layouts, components, composables, server routes, middleware and plugins, fetching data with `useFetch` and `useAsyncData`, adding or authoring a module, upgrading between major versions, and deploying to a specific provider. They cover Nuxt itself: for Vue, Vite, Nitro or UnJS APIs, go to their own documentation.',
-    `Every documentation, blog and deploy page is also Markdown. Append \`.md\` to a URL, or send \`Accept: text/markdown\` on the HTML one. <${domain}/llms-full.txt> is the whole documentation in a single file, and <${domain}/sitemap.md> lists every page. For search and structured lookups, call the MCP server at <${domain}/mcp> (streamable HTTP), described by <${domain}/.well-known/mcp/server-card.json>.`,
-    `The REST endpoints under \`/api/v1\` are public, read-only and need no credentials: the module directory, its health data, and the core and ecosystem teams. <${domain}/openapi.json> describes them.`
+    'Use these docs when you are writing, reviewing or debugging code for a Nuxt application: scaffolding a project, configuring `nuxt.config.ts`, picking a rendering mode per route, writing pages, layouts, components, composables, server routes, middleware and plugins, fetching data with `useFetch` and `useAsyncData`, adding or authoring a module, upgrading between major versions, and deploying to a specific provider.',
+    'They cover Nuxt itself. For Vue, Vite, Nitro or UnJS APIs, go to their own documentation, and for questions about a specific module, to the module\'s own docs, which the directory links.'
+  ]
+}
+
+/** How to fetch the documentation, for an agent that has decided to. */
+export function agentHowToCall(domain: string): string[] {
+  return [
+    `Every documentation, blog and deploy page is also Markdown. Append \`.md\` to a URL, or send \`Accept: text/markdown\` on the HTML one. <${domain}/llms-full.txt> is the whole documentation in a single file, and <${domain}/sitemap.md> lists every page.`,
+    `For search and structured lookups, call the MCP server at <${domain}/mcp> (streamable HTTP), described by <${domain}/.well-known/mcp/server-card.json>. The REST endpoints under \`/api/v1\` are public, read-only and need no credentials: the module directory, its health data, and the core and ecosystem teams. <${domain}/openapi.json> describes them.`
   ]
 }


### PR DESCRIPTION
Two follow-ups to #2409. The when-to-use guidance was there but not findable as a section, and no markdown twin was ever cached.

### The guidance gets its own section

`#2409` put the guidance in the details section of `/llms.txt`, the free prose [llmstxt.org](https://llmstxt.org) reserves between the blockquote and the first `##`. Nothing marks it as guidance there: no heading, and the text opened with "Reach for these docs when", so anything scanning headings or looking for the phrase walked straight past it.

`shared/utils/agents.ts` now splits in two. `agentWhenToUse()` (the jobs these docs answer, and the ones they don't) becomes an `llms.sections` entry rendering a literal `## When to use this`. `agentHowToCall(domain)` (markdown negotiation, `llms-full.txt`, `sitemap.md`, the MCP server, `openapi.json`) stays in the details slot, which is what that space is for.

Two details: the section carries the landing page link, which is what stops `nuxt-agent-discovery` prepending an `Overview` section of its own, and `server/plugins/llms.ts` pulls it ahead of the "Documentation Sets" block `nuxt-llms` injects. `/raw/index.md` gets the same split, as `## When to use this` and `## How to fetch these docs`.

### Markdown twins are prerendered again

`nitro.prerender.ignore` has excluded `/raw/**` since #2280, from before the migration to `nuxt-agent-discovery`. It stopped mattering when the module took over and started hinting each prerendered page's twin to the crawler, and it has been quietly defeating that ever since: not one twin was frozen, so every agent request rendered at the origin.

`x-vercel-cache: MISS` on every markdown response on production, always. The homepage twin runs 0.55s to 2.4s against 0.12s for the CDN-cached HTML, and docs twins 0.2s to 0.7s. Agents get the slowest version of every page on the site.

The module skips the twins we back with live handlers itself, so `/raw/modules.md` and `/raw/changelog.md` keep answering per request.

### Verification

`nuxt build` prerenders 3095 routes in 168s. 603 twins written, 4.5 MB against a 592 MB public output:

- `/raw/index.md` frozen at 4.6 kB, `/raw/docs/4.x/getting-started/introduction.md` at 6.7 kB
- `/raw/modules.md` and `/raw/changelog.md` correctly absent
- nightly 5.x twins stay out, 3.x and 4.x are in
- the built `llms.txt` carries `## When to use this` as its first section

Lint, typecheck and the test suite are clean.

I did not measure a before/after build time, so there is no delta to quote here: 603 extra routes out of 3095, and a markdown twin is far cheaper to render than the Vue page it mirrors.
