### PR TITLE
fix(docs): preserve query and hash in version redirects

### DIFF
--- a/app/middleware/docs-version.global.ts
+++ b/app/middleware/docs-version.global.ts
@@ -13,5 +13,9 @@ export default defineNuxtRouteMiddleware((to) => {
   // /docs/4.x/*. Note: prerendered pages can't emit a real HTTP redirect,
   // so the static output falls back to a meta-refresh stub — modern
   // crawlers and clients still follow it.
-  return navigateTo(to.fullPath.replace('/docs', `/docs/${CURRENT_DOCS_VERSION}`), { redirectCode: 302 })
+  return navigateTo({
+    path: to.path.replace('/docs', `/docs/${CURRENT_DOCS_VERSION}`),
+    query: to.query,
+    hash: to.hash
+  }, { redirectCode: 302 })
 })


### PR DESCRIPTION
## Linked Issue

Closes #2060


## Description

This change updates the documentation version redirect middleware to preserve the URL query parameters and hash fragment when redirecting to the current documentation version.

Previously, the redirect rebuilt the URL from to.fullPath, which could result in the URL hash being lost during the redirect.

The redirect now passes path, query, and hash explicitly to navigateTo().

## Testing

- `pnpm exec playwright test test/browser/pages.spec.ts --timeout=60000`
- 3 tests passed
- 1 test skipped (existing blog navigation test)
- 0 tests failed
- `git diff --check` passes
