### PR TITLE
fix(nuxi): retarget Vercel MCP to catalog endpoints

### DIFF
--- a/layers/nuxi/README.md
+++ b/layers/nuxi/README.md
@@ -134,7 +134,7 @@ Single Monday digest: traffic (trend, top sections, referrers/audience), docs fe
 - Schedule: `agent/schedules/weekly-digest.ts` — Monday 5:00 UTC
 - Skill: `agent/skills/weekly-digest/SKILL.md`
 - Preview trigger: `POST /eve/v1/ops/weekly-digest/trigger`
-- Traffic via `vercel-mcp__get_web_analytics`; spend via `ai_gateway__report` (scoped to `app:nuxi` tags and/or `AI_GATEWAY_REPORT_API_KEY_NAME` — never account-wide); runs via `vercel-mcp__list_agent_runs`.
+- Traffic via `vercel-mcp__search_vercel_endpoints` + `vercel-mcp__call_vercel_endpoint` (`GET /v1/query/web-analytics/visits/count` and `…/aggregate`); spend via `ai_gateway__report` (scoped to `app:nuxi` tags and/or `AI_GATEWAY_REPORT_API_KEY_NAME` — never account-wide); runs via `vercel-mcp__list_agent_runs`.
 
 ### Firehose summary
 

--- a/layers/nuxi/agent/channels/discord.ts
+++ b/layers/nuxi/agent/channels/discord.ts
@@ -3,7 +3,7 @@ import { createMemoryState } from '@chat-adapter/state-memory'
 import { createRedisState } from '@chat-adapter/state-redis'
 import type { UserContent } from 'ai'
 import type { Message, MessageContext, Thread } from 'chat'
-import { defineChannel } from 'eve/channels'
+import { defineChannel, POST } from 'eve/channels'
 import {
   chatSdkChannel,
   isNotImplemented,
@@ -319,7 +319,14 @@ const discordBridge: DiscordBridge | null = isDiscordConfigured()
 
 export const bot = discordBridge?.bot ?? null
 export const send = discordBridge?.send ?? null
-export const channel = discordBridge?.channel ?? defineChannel({ routes: [] })
+export const channel = discordBridge?.channel ?? defineChannel({
+  routes: [
+    POST('/eve/v1/discord', () => Response.json(
+      { error: 'Discord is not configured' },
+      { status: 503 }
+    ))
+  ]
+})
 
 /**
  * Post already-converted Discord markdown to a channel (no thread), skipping

--- a/layers/nuxi/agent/connections/vercel-mcp.ts
+++ b/layers/nuxi/agent/connections/vercel-mcp.ts
@@ -24,23 +24,23 @@ function adminOnlyVercelAuth(label: string, connectOptions: EveAuthorizationOpti
 
 const ALLOWED_TOOLS = [
   'search_vercel_documentation',
-  'list_deployments',
-  'get_deployment',
-  'get_deployment_build_logs',
+  'search_vercel_endpoints',
+  'call_vercel_endpoint',
   'get_runtime_logs',
   'get_runtime_errors',
-  'get_project',
   'list_agent_run_projects',
   'list_agent_runs',
-  'get_web_analytics'
+  'get_agent_run'
 ] as const
 
 export const VERCEL_MCP_INSTRUCTIONS = VERCEL_TEAM_ID && VERCEL_PROJECT_ID
   ? `**Vercel MCP connection (\`vercel-mcp__*\`, admin/Slack/schedule only) — read-only, use judiciously:**
 - Discover exact schemas via \`connection_search\`, then call \`vercel-mcp__<tool>\`.
-- The connection is pre-scoped to the \`nuxt-js\` team and the \`nuxt\` (nuxt.com website) project — \`teamId=${VERCEL_TEAM_ID}\`, \`projectId=${VERCEL_PROJECT_ID}\`. Pass both explicitly to \`list_deployments\`, \`get_deployment\`, \`get_deployment_build_logs\`, \`get_runtime_logs\`, \`get_runtime_errors\`, \`get_project\`, \`get_web_analytics\`.
-- Nuxi's own Agent Runs (\`list_agent_runs\`) use the same \`teamId\` but a DIFFERENT \`projectId\` — the \`eve\` service's own project, not the website. Call \`list_agent_run_projects\` first to discover it. Still NOT tokens/cost — use \`ai_gateway__*\` for that. No per-run trace access — this connection only exposes run-level metadata, never raw conversation content.
-- \`get_web_analytics\` (visitors/pageviews/custom events, production only): \`mode: 'count'\` (default) returns one total, e.g. "how many visitors this week"; \`mode: 'aggregate'\` groups by up to two \`by\` dimensions (hour/day/week/month/year, country, route, requestPath, referrerHostname, deviceType, browserName, eventName, flags/<name>, ...) and requires \`since\`+\`until\`. \`dataset: 'visits'\` (default) for pageviews, \`'events'\` for custom \`track()\` events. \`filter\` is OData, e.g. \`requestPath eq '/docs'\`. Requires Web Analytics enabled on the project.
+- Catalog: \`search_vercel_endpoints\` then \`call_vercel_endpoint\` with the returned endpoint id. **GET only** — never buy/deploy/mutate through this connection.
+- Pre-scoped to the \`nuxt-js\` team / \`nuxt\` website project — \`teamId=${VERCEL_TEAM_ID}\`, \`projectId=${VERCEL_PROJECT_ID}\`. Pass both on every call.
+- Traffic (production Web Analytics): \`GET /v1/query/web-analytics/visits/count\` for one total (\`visitors\` / \`pageviews\`); \`GET /v1/query/web-analytics/visits/aggregate\` for grouped rows (\`by\` + \`since\` + \`until\` required). Custom events: \`…/events/count\` and \`…/events/aggregate\`. \`filter\` is OData, e.g. \`requestPath eq '/docs'\`.
+- Runtime: \`get_runtime_errors\` first, then \`get_runtime_logs\`.
+- Nuxi's Agent Runs use the same \`teamId\` but a DIFFERENT \`projectId\` — the \`eve\` service, not the website. Call \`list_agent_run_projects\` first, then \`list_agent_runs\` / \`get_agent_run\`. Still NOT tokens/cost — use \`ai_gateway__*\`. Never fetch traces (\`get_agent_run_trace\` is not allowed).
 - \`search_vercel_documentation\` needs no ids — general Vercel platform docs search.`
   : ''
 

--- a/layers/nuxi/agent/connections/vercel-mcp.ts
+++ b/layers/nuxi/agent/connections/vercel-mcp.ts
@@ -37,10 +37,10 @@ export const VERCEL_MCP_INSTRUCTIONS = VERCEL_TEAM_ID && VERCEL_PROJECT_ID
   ? `**Vercel MCP connection (\`vercel-mcp__*\`, admin/Slack/schedule only) — read-only, use judiciously:**
 - Discover exact schemas via \`connection_search\`, then call \`vercel-mcp__<tool>\`.
 - Catalog: \`search_vercel_endpoints\` then \`call_vercel_endpoint\` with the returned endpoint id. **GET only** — never buy/deploy/mutate through this connection.
-- Pre-scoped to the \`nuxt-js\` team / \`nuxt\` website project — \`teamId=${VERCEL_TEAM_ID}\`, \`projectId=${VERCEL_PROJECT_ID}\`. Pass both on every call.
+- Pre-scoped to the \`nuxt-js\` team (\`teamId=${VERCEL_TEAM_ID}\`). For website analytics/runtime only, also pass \`projectId=${VERCEL_PROJECT_ID}\` (the \`nuxt\` site).
 - Traffic (production Web Analytics): \`GET /v1/query/web-analytics/visits/count\` for one total (\`visitors\` / \`pageviews\`); \`GET /v1/query/web-analytics/visits/aggregate\` for grouped rows (\`by\` + \`since\` + \`until\` required). Custom events: \`…/events/count\` and \`…/events/aggregate\`. \`filter\` is OData, e.g. \`requestPath eq '/docs'\`.
 - Runtime: \`get_runtime_errors\` first, then \`get_runtime_logs\`.
-- Nuxi's Agent Runs use the same \`teamId\` but a DIFFERENT \`projectId\` — the \`eve\` service, not the website. Call \`list_agent_run_projects\` first, then \`list_agent_runs\` / \`get_agent_run\`. Still NOT tokens/cost — use \`ai_gateway__*\`. Never fetch traces (\`get_agent_run_trace\` is not allowed).
+- Nuxi's Agent Runs use the same \`teamId\` but a DIFFERENT \`projectId\` — the \`eve\` service, not the website. Call \`list_agent_run_projects\` first and use that id on \`list_agent_runs\` / \`get_agent_run\`. Still NOT tokens/cost — use \`ai_gateway__*\`. Never fetch traces (\`get_agent_run_trace\` is not allowed).
 - \`search_vercel_documentation\` needs no ids — general Vercel platform docs search.`
   : ''
 

--- a/layers/nuxi/agent/skills/weekly-digest/SKILL.md
+++ b/layers/nuxi/agent/skills/weekly-digest/SKILL.md
@@ -17,16 +17,16 @@ Always write Slack mrkdwn (`<url|label>`, `:emoji:`). If this run is mirrored to
 
 **Data steps** (parallel where possible; Vercel / AI Gateway tools need admin/Slack/schedule-only access):
 
-Traffic (nuxt.com project — always pass `teamId`/`projectId`):
-1. `vercel-mcp__get_web_analytics` — `mode=count, dataset=visits` for the current window AND the previous window → visitors/pageviews + WoW %.
-2. `mode=aggregate, dataset=visits, by=['day']` current window → daily trend (spot spikes/drops).
-3. `mode=aggregate, dataset=visits, by=['route'], limit=10` current + previous window → top sections with per-route deltas.
-4. `mode=aggregate, dataset=visits, by=['referrerHostname'], limit=8` + `by=['country'], limit=5` + `by=['deviceType']` → audience snapshot.
+Traffic (nuxt.com project — always pass `teamId`/`projectId` via `search_vercel_endpoints` then `call_vercel_endpoint`, GET only):
+1. `GET /v1/query/web-analytics/visits/count` for the current window AND the previous window → visitors/pageviews + WoW %.
+2. `GET /v1/query/web-analytics/visits/aggregate` with `by=['day']` current window → daily trend (spot spikes/drops).
+3. Same aggregate with `by=['route'], limit=10` current + previous window → top sections with per-route deltas.
+4. Same aggregate with `by=['referrerHostname'], limit=8` + `by=['country'], limit=5` + `by=['deviceType']` → audience snapshot.
 
 Docs feedback:
 5. `admin-mcp__feedback-stats` — `topPages=5`
 6. `admin-mcp__list-feedback` — `ratings=["not-helpful", "confusing"]`, `limit=30`
-7. For each worst page from step 5/6: traffic from step 3, or a targeted `mode=count, filter="requestPath eq '<path>'"` if missing from top routes — weigh urgency by real visits.
+7. For each worst page from step 5/6: traffic from step 3, or a targeted `GET /v1/query/web-analytics/visits/count` with `filter="requestPath eq '<path>'"` if missing from top routes — weigh urgency by real visits.
 
 AI agent:
 8. `admin-mcp__agent-usage-stats` — web chat counts and vote quality

--- a/test/unit/chat-tools.spec.ts
+++ b/test/unit/chat-tools.spec.ts
@@ -45,7 +45,7 @@ describe('normalizeToolName', () => {
   })
 
   it('hyphenates connection tools that use underscores', () => {
-    expect(normalizeToolName('vercel-mcp__list_deployments')).toBe('list-deployments')
+    expect(normalizeToolName('vercel-mcp__call_vercel_endpoint')).toBe('call-vercel-endpoint')
   })
 
   it('leaves the discovery tool untouched', () => {


### PR DESCRIPTION
The Vercel MCP no longer exposes dedicated analytics and deployment tools. This updates Nuxi to discover and call the current endpoint catalog, while keeping website and Agent Run project scopes separate. It also adds a disabled Discord route so Eve can compile without Discord credentials.

## What changed

- Route Web Analytics through `search_vercel_endpoints` and `call_vercel_endpoint`, restricted to GET requests.
- Use the website project only for analytics/runtime calls and resolve the Eve project separately for Agent Runs.
- Return `503` from `/eve/v1/discord` when Discord is not configured, keeping the channel manifest valid.

## Before and after

### Vercel MCP analytics discovery

The same `connection_search` call returned no analytics capability before and the endpoint catalog caller after.

| Before | After |
|:------:|:-----:|
| ![Before: connection_search returns only runtime tools](https://github.com/user-attachments/assets/8e849021-a258-460d-bd59-3c12f1e6a428) | ![After: connection_search returns call_vercel_endpoint](https://github.com/user-attachments/assets/438605ae-95a9-4435-8a1d-ce85c20e1e31) |

> The unrelated Discord compile blocker was neutralized in the isolated base worktree so both revisions could run the same MCP call.

### Build without Discord credentials

The same build failed on the base revision because the disabled channel had no manifest route. It completes successfully after this change.

| Before | After |
|:------:|:-----:|
| ![Before: Eve build fails with an unreferenced Discord binding](https://github.com/user-attachments/assets/aeced665-251f-419c-9eef-15ee9e840d9e) | ![After: Eve build completes without Discord credentials](https://github.com/user-attachments/assets/a0b9558e-c186-4b9a-a115-85237fe374b7) |

## Validation

- `pnpm test:unit --run test/unit/chat-tools.spec.ts` — 11 tests passed
- Reproduced the same `connection_search` call against base and head
- Reproduced the Discord-disabled build against base and head
- CI lint, unit tests, typecheck, CodeQL, bundle analysis, and Vercel deployment passed
